### PR TITLE
Initial Python bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.swp
 build
+.project
+.cproject
+.pydevproject
+*.pyc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ else()
     set (BUILDLOC ${BUILDEM_DIR})
 endif()
 
+
+set (LIBDVID_WRAP_PYTHON NO CACHE BOOL "Build the libdvid python bindings (requires boost_python)")
+
 if (NOT ${BUILDEM_DIR} STREQUAL "None")
     ###############################################################################
     # Download and install buildem, if it isn't already in BUILDEM_DIR.
@@ -70,6 +73,10 @@ if (NOT ${BUILDEM_DIR} STREQUAL "None")
     set (LIBDVID_DEPS ${jsoncpp_NAME} ${libpng_NAME} ${libcurl_NAME}
         ${libjpeg_NAME} ${lz4_NAME} ${boost_NAME})
     set (boost_LIBS ${BUILDEM_LIB_DIR}/libboost_system.${BUILDEM_PLATFORM_DYLIB_EXTENSION})
+    if (LIBDVID_WRAP_PYTHON)
+        set(boost_LIBS ${boost_LIBS} 
+                       ${BUILDEM_LIB_DIR}/libboost_python${BUILDEM_PLATFORM_DYLIB_EXTENSION})
+    endif()
     set (support_LIBS ${json_LIB} 
                       ${boost_LIBS} 
                       ${BUILDEM_LIB_DIR}/libpng${BUILDEM_PLATFORM_DYLIB_EXTENSION} 
@@ -82,6 +89,9 @@ else ()
 
     set (json_LIB jsoncpp)
     set (boost_LIBS boost_system)
+    if (LIBDVID_WRAP_PYTHON)
+        set(boost_LIBS ${boost_LIBS} boost_python)
+    endif()
     set (support_LIBS ${json_LIB} ${boost_LIBS} png curl jpeg lz4)
 endif (NOT ${BUILDEM_DIR} STREQUAL "None")
 
@@ -124,6 +134,10 @@ else()
     COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/libdvidcppConfig.cmake ${BUILDEM_DIR}/lib/libdvidcpp/libdvidcppConfig.cmake
     COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/libdvidcppTargets.cmake ${BUILDEM_DIR}/lib/libdvidcpp/libdvidcppTargets.cmake
     )
+endif()
+
+if (LIBDVID_WRAP_PYTHON)
+    add_subdirectory(python)    
 endif()
 
 add_executable(dvidtest_newrepo "tests/test_newrepo.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project (libdvidcpp)
 
 include (ExternalProject)
 
+enable_testing()
+
 set (RUN_ENVIRONMENT "Workstation" CACHE TYPE STRING)
 if (NOT CMAKE_BUILD_TYPE)
     set (CMAKE_BUILD_TYPE Release)
@@ -172,8 +174,6 @@ target_link_libraries(dvidloadtest_labelgraph dvidcpp ${support_LIBS})
 
 add_executable(dvidloadtest_tile "load_tests/loadtest_tile.cpp")
 target_link_libraries(dvidloadtest_tile dvidcpp ${support_LIBS})
-
-enable_testing()
 
 add_test(
     newrepo

--- a/libdvid/DVIDConnection.h
+++ b/libdvid/DVIDConnection.h
@@ -68,7 +68,7 @@ class DVIDConnection {
     */ 
     int make_request(std::string endpoint, ConnectionMethod method, BinaryDataPtr payload,
             BinaryDataPtr results, std::string& error_msg, ConnectionType type=DEFAULT,
-            int timeout=TIMEOUT); 
+            int timeout=DEFAULT_TIMEOUT);
 
     /*!
      * Get the address for the DVID connection.
@@ -86,6 +86,9 @@ class DVIDConnection {
         return (addr + DVID_PREFIX);
     }
 
+    //! default timeout in seconds
+    static const int DEFAULT_TIMEOUT = 60;
+
   private:
     /*!
      * Assignment doesn't really make much sense -- just disable.
@@ -101,9 +104,6 @@ class DVIDConnection {
 
     //! prefix for all DVID calls (versioning may be added here in the future) 
     static std::string DVID_PREFIX;
-
-    //! default timeout in seconds
-    static const int TIMEOUT = 60;
 };
 
 }

--- a/libdvid/DVIDNodeService.h
+++ b/libdvid/DVIDNodeService.h
@@ -242,7 +242,7 @@ class DVIDNodeService {
      * \param throttle allow only one request at time (default: true)
      * \param compress enable lz4 compression
     */
-    void put_gray3D(std::string datatype_instance, Grayscale3D& volume,
+    void put_gray3D(std::string datatype_instance, Grayscale3D const & volume,
             std::vector<unsigned int> offset, bool throttle=true,
             bool compress=false);
 
@@ -265,7 +265,7 @@ class DVIDNodeService {
      * \param roi specify DVID roi to mask PUT operation (default: empty)
      * \param compress enable lz4 compression
     */
-    void put_labels3D(std::string datatype_instance, Labels3D& volume,
+    void put_labels3D(std::string datatype_instance, Labels3D const & volume,
             std::vector<unsigned int> offset, bool throttle=true,
             bool compress=true, std::string roi="");
 

--- a/libdvid/DVIDVoxels.h
+++ b/libdvid/DVIDVoxels.h
@@ -116,7 +116,7 @@ class DVIDVoxels {
      * Retrieve binary data for the given volume.
      * \return binary data for volume
     */
-    BinaryDataPtr get_binary()
+    BinaryDataPtr get_binary() const
     {
         return data;
     }

--- a/libdvid/DVIDVoxels.h
+++ b/libdvid/DVIDVoxels.h
@@ -12,7 +12,9 @@
 #include "Globals.h"
 
 #include <string>
+#include <sstream>
 #include <vector>
+#include <boost/foreach.hpp>
 
 namespace libdvid {
 
@@ -66,7 +68,14 @@ class DVIDVoxels {
             }
         }
         if (total*sizeof(T) != data->length()) {
-            throw ErrMsg("Dimension mismatch with buffer size");
+            std::stringstream ssMsg;
+            ssMsg << "Dimensions ( ";
+            BOOST_FOREACH( Dims_t::value_type d, dims )
+            {
+                ssMsg << d << " ";
+            }
+            ssMsg << ") do not match buffer size (" << data->length() << ").";
+            throw ErrMsg( ssMsg.str() );
         }
     }
 

--- a/libdvid/DVIDVoxels.h
+++ b/libdvid/DVIDVoxels.h
@@ -134,7 +134,7 @@ class DVIDVoxels {
      * Get the dimensions of this volume.
      * \return volume dimensions
     */
-    Dims_t get_dims() const
+    Dims_t const & get_dims() const
     {
         return dims;
     }

--- a/libdvid/DVIDVoxels.h
+++ b/libdvid/DVIDVoxels.h
@@ -31,6 +31,10 @@ typedef std::vector<unsigned int> Dims_t;
 template <typename T, unsigned int N>
 class DVIDVoxels {
   public:
+
+    typedef T voxel_type;
+    const static int num_dims = N;
+
     /*!
      * Construtor takes a constant buffer, creates a binary
      * buffer of a certain length and associates it with

--- a/libdvid/Globals.h
+++ b/libdvid/Globals.h
@@ -8,23 +8,16 @@
 #ifndef DVIDGLOBALS_H
 #define DVIDGLOBALS_H
 
-#include <boost/static_assert.hpp>
+#include <boost/cstdint.hpp>
 #include <climits>
 
 namespace libdvid {
 
-//! Asssume long long are 64 bits
-//! TODO: make more robust for more build environments
-typedef unsigned long long uint64;
-
-//! Ensure uint64 is 8 bytes
-BOOST_STATIC_ASSERT(sizeof(uint64) == 8);
+typedef boost::uint8_t uint8;
+typedef boost::uint64_t uint64;
 
 //! By default everything in DVID has 32x32x32 blocks
 const int DEFBLOCKSIZE = 32;
-
-//! Grayscale type is 1 byte
-typedef unsigned char uint8;
 
 //! Gives the limit for how many vertice can be operated on in one call
 const int TransactionLimit = 1000;

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -146,3 +146,19 @@ install(TARGETS _dvid_python
         LIBRARY DESTINATION ${LIBDVID_PYTHON_INSTALL_DIR}/libdvid)
 install(FILES libdvid/__init__.py 
         DESTINATION ${LIBDVID_PYTHON_INSTALL_DIR}/libdvid)
+
+######################################################################
+#
+#      specify python tests
+#
+######################################################################
+add_test(
+    python_test_connection
+    ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_connection.py
+)
+
+add_test(
+    python_test_node_service
+    ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_node_service.py
+)
+        

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,147 @@
+cmake_minimum_required (VERSION 2.8) 
+
+######################################################################
+#
+#      find Python interpreter
+#
+######################################################################
+
+FIND_PACKAGE(PythonInterp 2 REQUIRED)
+
+IF(PYTHONINTERP_FOUND)
+    # check that Python version 2.x is used
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+                         "import sys; print(sys.version[0])"
+                          OUTPUT_VARIABLE PYTHON_MAJOR_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+    IF(NOT (${PYTHON_MAJOR_VERSION} EQUAL 2))
+        MESSAGE(FATAL_ERROR "Python bindings require Python 2.x.")
+    ENDIF()
+ENDIF()
+
+######################################################################
+#
+#      find Python library
+#
+######################################################################
+
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+                 "import sys; print sys.exec_prefix"
+                  OUTPUT_VARIABLE PYTHON_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+IF(APPLE AND ${PYTHON_PREFIX} MATCHES ".*framework.*")
+    SET(PYTHON_LIBRARIES "${PYTHON_PREFIX}/Python"
+        CACHE FILEPATH "Python libraries"
+        FORCE)
+ELSE()
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+                     "import sys; skip = 2 if sys.platform.startswith('win') else 1; print 'python' + sys.version[0:3:skip]"
+                      OUTPUT_VARIABLE PYTHON_LIBRARY_NAME OUTPUT_STRIP_TRAILING_WHITESPACE)
+    FIND_LIBRARY(PYTHON_LIBRARIES ${PYTHON_LIBRARY_NAME} HINTS "${PYTHON_PREFIX}" 
+                 PATH_SUFFIXES lib lib64 libs DOC "Python libraries")
+ENDIF()
+
+######################################################################
+#
+#      find Python includes
+#
+######################################################################
+
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+                "from distutils.sysconfig import *; print get_python_inc()"
+                OUTPUT_VARIABLE PYTHON_INCLUDE OUTPUT_STRIP_TRAILING_WHITESPACE)
+SET(PYTHON_INCLUDE_PATH ${PYTHON_INCLUDE}
+    CACHE PATH "Path to Python include files"
+    FORCE)
+
+######################################################################
+#
+#      find default install directory for Python modules
+#      (usually PYTHONDIR/Lib/site-packages)
+#
+######################################################################
+IF(NOT DEFINED LIBDVID_PYTHON_INSTALL_DIR OR LIBDVID_PYTHON_INSTALL_DIR MATCHES "^$")
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+                     "from distutils.sysconfig import *; print get_python_lib(1)"
+                      OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+    FILE(TO_CMAKE_PATH ${PYTHON_SITE_PACKAGES} LIBDVID_PYTHON_INSTALL_DIR)
+ENDIF()
+SET(LIBDVID_PYTHON_INSTALL_DIR ${LIBDVID_PYTHON_INSTALL_DIR}
+    CACHE PATH "where to install the libdvid Python package" FORCE)
+# this is the install path relative to CMAKE_INSTALL_PREFIX,
+# use this in INSTALL() commands to get packaging right
+FILE(RELATIVE_PATH LIBDVID_PYTHON_INSTALL_DIR ${CMAKE_INSTALL_PREFIX} ${LIBDVID_PYTHON_INSTALL_DIR})
+
+######################################################################
+#
+#      find numpy include directory
+#      (usually below PYTHONDIR/Lib/site-packages/numpy)
+#
+######################################################################
+IF(NOT PYTHON_NUMPY_INCLUDE_DIR)
+    # Note: we must suppress possible output of the 'from numpy... import *' command,
+    #       because the output cannot be interpreted correctly otherwise
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+                     "import sys, os; sys.stdout = open(os.devnull, 'w'); from numpy.distutils.misc_util import *; sys.__stdout__.write(' '.join(get_numpy_include_dirs()))"
+                      RESULT_VARIABLE PYTHON_NUMPY_NOT_FOUND
+                      OUTPUT_VARIABLE PYTHON_NUMPY_INCLUDE_DIR
+                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    IF(NOT PYTHON_NUMPY_NOT_FOUND)
+        FILE(TO_CMAKE_PATH ${PYTHON_NUMPY_INCLUDE_DIR} PYTHON_NUMPY_INCLUDE_DIR)
+    ELSE()
+        SET(PYTHON_NUMPY_INCLUDE_DIR "PYTHON_NUMPY_INCLUDE_DIR-NOTFOUND")
+    ENDIF()
+ENDIF()
+
+SET(PYTHON_NUMPY_INCLUDE_DIR ${PYTHON_NUMPY_INCLUDE_DIR}
+    CACHE PATH "Path to numpy include files" FORCE)
+    
+######################################################################
+#
+#      status output
+#
+######################################################################
+IF(PYTHON_LIBRARIES AND PYTHON_INCLUDE_PATH)
+    MESSAGE(STATUS "Found Python libraries: ${PYTHON_LIBRARIES}")
+    MESSAGE(STATUS "Found Python includes:  ${PYTHON_INCLUDE_PATH}")
+    SET(PYTHONLIBS_FOUND TRUE)
+ELSE()
+    MESSAGE(FATAL_ERROR "Could NOT find Python libraries and/or includes")
+ENDIF()
+    
+IF(PYTHON_NUMPY_INCLUDE_DIR)
+    MESSAGE(STATUS "Python numpy includes: ${PYTHON_NUMPY_INCLUDE_DIR}")
+ELSE()
+    MESSAGE(FATAL_ERROR "Could NOT find Python numpy ('import numpy.distutils.misc_util' failed)")
+ENDIF()
+
+######################################################################
+#
+#      configure package
+#
+######################################################################
+
+include_directories(${PYTHON_INCLUDE_PATH} ${PYTHON_NUMPY_INCLUDE_DIR})
+
+if (NOT MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+endif()
+
+add_library( _dvid_python SHARED src/libdvid_python.cpp )
+
+target_link_libraries( _dvid_python dvidcpp ${support_LIBS} ${PYTHON_LIBRARIES} )
+set_target_properties( _dvid_python PROPERTIES PREFIX  "")
+
+if (APPLE)
+    set_target_properties( _dvid_python PROPERTIES SUFFIX  ".so")
+endif()
+
+if (NOT (APPLE OR MSVC))
+    # FIXME: This may not be needed anymore because timing now uses std::chrono
+    target_link_libraries( _dvid_python rt)
+endif()
+
+install(TARGETS _dvid_python
+        RUNTIME DESTINATION ${LIBDVID_PYTHON_INSTALL_DIR}/libdvid
+        LIBRARY DESTINATION ${LIBDVID_PYTHON_INSTALL_DIR}/libdvid)
+install(FILES libdvid/__init__.py 
+        DESTINATION ${LIBDVID_PYTHON_INSTALL_DIR}/libdvid)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -129,7 +129,8 @@ endif()
 add_library( _dvid_python SHARED src/libdvid_python.cpp )
 
 target_link_libraries( _dvid_python dvidcpp ${support_LIBS} ${PYTHON_LIBRARIES} )
-set_target_properties( _dvid_python PROPERTIES PREFIX  "")
+set_target_properties( _dvid_python PROPERTIES PREFIX  ""
+                                               DEBUG_POSTFIX "" )
 
 if (APPLE)
     set_target_properties( _dvid_python PROPERTIES SUFFIX  ".so")

--- a/python/libdvid/__init__.py
+++ b/python/libdvid/__init__.py
@@ -1,0 +1,1 @@
+from _dvid_python import *

--- a/python/libdvid/_dvid_python.so
+++ b/python/libdvid/_dvid_python.so
@@ -1,0 +1,1 @@
+../../build/python/_dvid_python.so

--- a/python/libdvid/libdvid_python.so
+++ b/python/libdvid/libdvid_python.so
@@ -1,1 +1,0 @@
-../../build/python/libdvid_python.so

--- a/python/libdvid/libdvid_python.so
+++ b/python/libdvid/libdvid_python.so
@@ -1,0 +1,1 @@
+../../build/python/libdvid_python.so

--- a/python/src/converters.hpp
+++ b/python/src/converters.hpp
@@ -319,5 +319,25 @@ namespace libdvid { namespace python {
             return array_object;
         }
     };
+
+    //!*********************************************************************************************
+    //! This converts Json::Value objects into python dict objects.
+    //! NOTE: This isn't an efficient conversion method.
+    //!*********************************************************************************************
+    struct json_value_to_dict
+    {
+        static PyObject* convert(Json::Value const & json_value)
+        {
+            using namespace boost::python;
+
+            // For now, easiest thing to do is just export as
+            //  string and re-parse via python's json module.
+            std::ostringstream ss;
+            ss << json_value;
+
+            object json = import("json");
+            return incref(json.attr("loads")( ss.str() ).ptr());
+        }
+    };
     
 }} // namespace libdvid::python

--- a/python/src/converters.hpp
+++ b/python/src/converters.hpp
@@ -1,0 +1,105 @@
+#include <vector>
+#include <string>
+#include <boost/python.hpp>
+
+using namespace boost::python;
+
+namespace libdvid { namespace python {
+
+    /*
+     * This struct tells boost::python how to convert Python sequences into std::vector<T>.
+     * To use it, instantiate a single instance of it somewhere in your module init section:
+     * 
+     *     libdvid::python::std_vector_from_python_iterable<unsigned int>();
+     * 
+     * NOTE: This does NOT convert the other way, i.e. from std::vector<T> into Python list.
+     *       If you need to return a std::vector<T>, you'll have to implement that separately.
+     * 
+     * For explanation and examples, see the following links:
+     * https://misspent.wordpress.com/2009/09/27/how-to-write-boost-python-converters
+     * http://www.boost.org/doc/libs/1_39_0/libs/python/doc/v2/faq.html#custom_string
+     */
+    template <typename T>
+    struct std_vector_from_python_iterable
+    {
+        typedef std::vector<T> vector_t;
+    
+        std_vector_from_python_iterable()
+        {
+          converter::registry::push_back(
+              &convertible,
+              &construct,
+              type_id<vector_t>());
+        }
+    
+        // Determine if obj_ptr can be converted in a vector
+        static void* convertible(PyObject* obj_ptr)
+        {
+            if (!PySequence_Check(obj_ptr))
+            {
+                return 0;
+            }
+            return obj_ptr;
+        }
+    
+        // Convert obj_ptr into a vector
+        static void construct( PyObject* obj_ptr, converter::rvalue_from_python_stage1_data* data)
+        {
+            assert( PySequence_Check(obj_ptr) );
+    
+            // Grab pointer to memory into which to construct the new vector_t
+            void* storage = ((converter::rvalue_from_python_storage<vector_t>*) data)->storage.bytes;
+    
+            // in-place construct the new vector_t
+            vector_t * the_vector = new (storage) vector_t;
+    
+            // Now copy the data from python into the vector
+            typedef stl_input_iterator<T> vector_iter_t;
+            object obj = object(handle<>(obj_ptr));
+            the_vector->assign( vector_iter_t(obj), vector_iter_t()  );
+    
+            // Stash the memory chunk pointer for later use by boost::python
+            data->convertible = storage;
+        }
+    };
+
+    /*
+     * This converter auto-converts 'None' objects into empty std::strings.
+     */
+    struct std_string_from_python_none
+    {
+        std_string_from_python_none()
+        {
+          converter::registry::push_back(
+              &convertible,
+              &construct,
+              type_id<std::string>());
+        }
+    
+        // Determine if obj_ptr is None
+        static void* convertible(PyObject* obj_ptr)
+        {
+            if (obj_ptr == Py_None)
+            {
+                return obj_ptr;
+            }
+            return 0;
+        }
+    
+        // Convert obj_ptr into a std::string
+        static void construct( PyObject* obj_ptr, converter::rvalue_from_python_stage1_data* data)
+        {
+            assert (obj_ptr == Py_None);
+    
+            // Grab pointer to memory into which to construct the std::string
+            void* storage = ((converter::rvalue_from_python_storage<std::string>*) data)->storage.bytes;
+    
+            // in-place construct the new std::string
+            // extraced from the python object
+            new (storage) std::string;
+        
+            // Stash the memory chunk pointer for later use by boost.python
+            data->convertible = storage;
+        }
+    };
+}}

--- a/python/src/converters.hpp
+++ b/python/src/converters.hpp
@@ -350,11 +350,11 @@ namespace libdvid { namespace python {
             // Copy dims to type numpy expects.
             std::vector<npy_intp> numpy_dims( volume.get_dims().begin(), volume.get_dims().end() );
     
-            // We will create a new array with the data from the existing PyBinaryData object (no copy).
+            // We will create a new array with the data from the existing PyBinaryDataHolder object (no copy).
             // The basic idea is described in the following link, but can get away with a lot less code
-            // because boost-python already defined the new Python type for us (PyBinaryData).
-            // Also, this post is old so the particular API we're using here is slightly different.
-            // http://blog.enthought.com/python/numpy-arrays-with-pre-allocated-memory/
+            // because we used boost-python to define the Python type (PyBinaryDataHolder).
+            // (Note: this post is old, so the particular API we're using here is slightly different.)
+            // http://blog.enthought.com/python/numpy-arrays-with-pre-allocated-memory
             void const * raw_data = static_cast<void const*>(volume_data->get_raw());
             PyObject * array_object = PyArray_SimpleNewFromData( numpy_dims.size(),
                                                                  &numpy_dims[0],

--- a/python/src/libdvid_python.cpp
+++ b/python/src/libdvid_python.cpp
@@ -17,122 +17,126 @@
 
 #include "converters.hpp"
 
-//! Python wrapper function for DVIDConnection::make_request().
-//! Since "return-by-reference" is not an option in Python, this function can't be directly wrapped.
-//! Returns a tuple: (status, result_body, error_msg)
-boost::python::tuple make_request( libdvid::DVIDConnection & connection,
-                                   std::string endpoint,
-                                   libdvid::ConnectionMethod method,
-                                   libdvid::BinaryDataPtr payload_data,
-                                   int timeout )
-{
-    using namespace libdvid;
-    using namespace boost::python;
+namespace libdvid { namespace python {
 
-    BinaryDataPtr results = BinaryData::create_binary_data();
-    std::string err_msg ;
+    //! Python wrapper function for DVIDConnection::make_request().
+    //! Since "return-by-reference" is not an option in Python, this function can't be directly wrapped.
+    //! Returns a tuple: (status, result_body, error_msg)
+    boost::python::tuple make_request( DVIDConnection & connection,
+                                       std::string endpoint,
+                                       ConnectionMethod method,
+                                       BinaryDataPtr payload_data,
+                                       int timeout )
+    {
+        using namespace libdvid;
+        using namespace boost::python;
 
-    int status_code = connection.make_request(endpoint, method, payload_data, results, err_msg, DEFAULT, timeout);
-    return make_tuple(status_code, object(results), err_msg);
-}
+        BinaryDataPtr results = BinaryData::create_binary_data();
+        std::string err_msg ;
 
-/*
- * Initialize the Python module (_dvid_python)
- * This cpp file should be built as _dvid_python.so
- */
-BOOST_PYTHON_MODULE(_dvid_python)
-{
-    using namespace libdvid;
-    using namespace boost::python;
+        int status_code = connection.make_request(endpoint, method, payload_data, results, err_msg, DEFAULT, timeout);
+        return make_tuple(status_code, object(results), err_msg);
+    }
 
-    // http://docs.scipy.org/doc/numpy/reference/c-api.array.html#importing-the-api
-    import_array()
+    /*
+     * Initialize the Python module (_dvid_python)
+     * This cpp file should be built as _dvid_python.so
+     */
+    BOOST_PYTHON_MODULE(_dvid_python)
+    {
+        using namespace libdvid;
+        using namespace boost::python;
 
-    // Register custom Python -> C++ converters.
-    libdvid::python::std_vector_from_python_iterable<unsigned int>();
-    libdvid::python::std_string_from_python_none(); // None -> std::string("")
-    libdvid::python::binary_data_ptr_from_python_buffer();
+        // http://docs.scipy.org/doc/numpy/reference/c-api.array.html#importing-the-api
+        import_array()
 
-    libdvid::python::ndarray_to_volume<Grayscale3D>();
-    libdvid::python::ndarray_to_volume<Labels3D>();
-    libdvid::python::ndarray_to_volume<Grayscale2D>();
-    libdvid::python::ndarray_to_volume<Labels2D>();
+        // Register custom Python -> C++ converters.
+        std_vector_from_python_iterable<unsigned int>();
+        std_string_from_python_none(); // None -> std::string("")
+        binary_data_ptr_from_python_buffer();
 
-    // Register custom C++ -> Python converters.
-    to_python_converter<BinaryDataPtr, libdvid::python::binary_data_ptr_to_python_str>();
-    to_python_converter<Json::Value, libdvid::python::json_value_to_dict>();
+        ndarray_to_volume<Grayscale3D>();
+        ndarray_to_volume<Labels3D>();
+        ndarray_to_volume<Grayscale2D>();
+        ndarray_to_volume<Labels2D>();
 
-    to_python_converter<Grayscale3D, libdvid::python::volume_to_ndarray<Grayscale3D> >();
-    to_python_converter<Labels3D, libdvid::python::volume_to_ndarray<Labels3D> >();
-    to_python_converter<Grayscale2D, libdvid::python::volume_to_ndarray<Grayscale2D> >();
-    to_python_converter<Labels2D, libdvid::python::volume_to_ndarray<Labels2D> >();
+        // Register custom C++ -> Python converters.
+        to_python_converter<BinaryDataPtr, binary_data_ptr_to_python_str>();
+        to_python_converter<Json::Value, json_value_to_dict>();
 
-    // DVIDConnection python class definition
-    class_<DVIDConnection>("DVIDConnection", init<std::string>())
-        .def("make_request", &make_request,
-                             ( arg("connection"), arg("endpoint"), arg("method"), arg("payload")=object(), arg("timeout")=DVIDConnection::DEFAULT_TIMEOUT ))
-        .def("get_addr", &DVIDConnection::get_addr)
-        .def("get_uri_root", &DVIDConnection::get_uri_root)
-    ;
+        to_python_converter<Grayscale3D, volume_to_ndarray<Grayscale3D> >();
+        to_python_converter<Labels3D, volume_to_ndarray<Labels3D> >();
+        to_python_converter<Grayscale2D, volume_to_ndarray<Grayscale2D> >();
+        to_python_converter<Labels2D, volume_to_ndarray<Labels2D> >();
 
-    enum_<ConnectionMethod>("ConnectionMethod")
-        .value("GET", GET)
-        .value("POST", POST)
-        .value("PUT", PUT)
-        .value("DELETE", DELETE)
-    ;
+        // DVIDConnection python class definition
+        class_<DVIDConnection>("DVIDConnection", init<std::string>())
+            .def("make_request", &make_request,
+                                 ( arg("connection"), arg("endpoint"), arg("method"), arg("payload")=object(), arg("timeout")=DVIDConnection::DEFAULT_TIMEOUT ))
+            .def("get_addr", &DVIDConnection::get_addr)
+            .def("get_uri_root", &DVIDConnection::get_uri_root)
+        ;
 
-    // DVIDServerService python class definition
-    class_<DVIDServerService>("DVIDServerService", init<std::string>())
-        .def("create_new_repo", &DVIDServerService::create_new_repo)
-    ;
+        enum_<ConnectionMethod>("ConnectionMethod")
+            .value("GET", GET)
+            .value("POST", POST)
+            .value("PUT", PUT)
+            .value("DELETE", DELETE)
+        ;
 
-    // For overloaded functions, boost::python needs help figuring out which one we're aiming for.
-    // These function pointers specify the ones we want.
-    void (DVIDNodeService::*put_binary)(std::string, std::string, BinaryDataPtr) = &DVIDNodeService::put;
-    Grayscale3D (DVIDNodeService::*get_gray3D)(std::string, Dims_t, std::vector<unsigned int>, bool, bool, std::string) = &DVIDNodeService::get_gray3D;
-    Labels3D (DVIDNodeService::*get_labels3D)(std::string, Dims_t, std::vector<unsigned int>, bool, bool, std::string) = &DVIDNodeService::get_labels3D;
-    void (DVIDNodeService::*put_gray3D)(std::string, Grayscale3D const&, std::vector<unsigned int>, bool, bool) = &DVIDNodeService::put_gray3D;
-    void (DVIDNodeService::*put_labels3D)(std::string, Labels3D const&, std::vector<unsigned int>, bool, bool, std::string) = &DVIDNodeService::put_labels3D;
+        // DVIDServerService python class definition
+        class_<DVIDServerService>("DVIDServerService", init<std::string>())
+            .def("create_new_repo", &DVIDServerService::create_new_repo)
+        ;
 
-    // DVIDNodeService python class definition
-    class_<DVIDNodeService>("DVIDNodeService", init<std::string, UUID>())
-        .def("get_typeinfo", &DVIDNodeService::get_typeinfo)
-        .def("create_graph", &DVIDNodeService::create_graph)
-        .def("custom_request", &DVIDNodeService::custom_request)
-        
-        // keyvalue
-        .def("create_keyvalue", &DVIDNodeService::create_keyvalue)
-        .def("put", put_binary)
-        .def("get", &DVIDNodeService::get)
-        .def("get_json", &DVIDNodeService::get_json)
+        // For overloaded functions, boost::python needs help figuring out which one we're aiming for.
+        // These function pointers specify the ones we want.
+        void (DVIDNodeService::*put_binary)(std::string, std::string, BinaryDataPtr) = &DVIDNodeService::put;
+        Grayscale3D (DVIDNodeService::*get_gray3D)(std::string, Dims_t, std::vector<unsigned int>, bool, bool, std::string) = &DVIDNodeService::get_gray3D;
+        Labels3D (DVIDNodeService::*get_labels3D)(std::string, Dims_t, std::vector<unsigned int>, bool, bool, std::string) = &DVIDNodeService::get_labels3D;
+        void (DVIDNodeService::*put_gray3D)(std::string, Grayscale3D const&, std::vector<unsigned int>, bool, bool) = &DVIDNodeService::put_gray3D;
+        void (DVIDNodeService::*put_labels3D)(std::string, Labels3D const&, std::vector<unsigned int>, bool, bool, std::string) = &DVIDNodeService::put_labels3D;
 
-        // grayscale
-        .def("create_grayscale8", &DVIDNodeService::create_grayscale8)
-        .def("get_gray3D", get_gray3D,
-            ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
-        .def("put_gray3D", put_gray3D,
-            ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false))
+        // DVIDNodeService python class definition
+        class_<DVIDNodeService>("DVIDNodeService", init<std::string, UUID>())
+            .def("get_typeinfo", &DVIDNodeService::get_typeinfo)
+            .def("create_graph", &DVIDNodeService::create_graph)
+            .def("custom_request", &DVIDNodeService::custom_request)
 
-        // labels
-       .def("create_labelblk", &DVIDNodeService::create_labelblk)
-       .def("get_labels3D", get_labels3D,
-            ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
-       .def("put_labels3D", put_labels3D,
-            ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
+            // keyvalue
+            .def("create_keyvalue", &DVIDNodeService::create_keyvalue)
+            .def("put", put_binary)
+            .def("get", &DVIDNodeService::get)
+            .def("get_json", &DVIDNodeService::get_json)
 
-        // 2D slices
-        .def("get_tile_slice", &DVIDNodeService::get_tile_slice)
-        .def("get_tile_slice_binary", &DVIDNodeService::get_tile_slice_binary)
-    ;
+            // grayscale
+            .def("create_grayscale8", &DVIDNodeService::create_grayscale8)
+            .def("get_gray3D", get_gray3D,
+                ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
+            .def("put_gray3D", put_gray3D,
+                ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false))
 
-    enum_<Slice2D>("Slice2D")
-        .value("XY", XY)
-        .value("XZ", XZ)
-        .value("YZ", YZ)
-    ;
+            // labels
+           .def("create_labelblk", &DVIDNodeService::create_labelblk)
+           .def("get_labels3D", get_labels3D,
+                ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
+           .def("put_labels3D", put_labels3D,
+                ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
 
-    // Define a python version of BinaryDataHolder, and keep a global
-    //  reference to it so we can instantiate it ourselves.
-    libdvid::python::PyBinaryDataHolder = class_<libdvid::python::BinaryDataHolder>("BinaryDataHolder");
-}
+            // 2D slices
+            .def("get_tile_slice", &DVIDNodeService::get_tile_slice)
+            .def("get_tile_slice_binary", &DVIDNodeService::get_tile_slice_binary)
+        ;
+
+        enum_<Slice2D>("Slice2D")
+            .value("XY", XY)
+            .value("XZ", XZ)
+            .value("YZ", YZ)
+        ;
+
+        // Define a python version of BinaryDataHolder, and keep a global
+        //  reference to it so we can instantiate it ourselves.
+        PyBinaryDataHolder = class_<BinaryDataHolder>("BinaryDataHolder");
+    }
+
+}} // namespace libdvid::python

--- a/python/src/libdvid_python.cpp
+++ b/python/src/libdvid_python.cpp
@@ -1,6 +1,10 @@
 #include <Python.h>
 #include <boost/python.hpp>
 #include <boost/python/stl_iterator.hpp>
+#include <boost/bind.hpp>
+#include <boost/function.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/assign/list_of.hpp>
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
@@ -16,15 +20,12 @@
 #include "DVIDNodeService.h"
 #include "DVIDException.h"
 
-// PyBinaryData is the Python wrapper class defined below for the BinaryData class.
-// It is exposed here as a global so helper functions can instantiate new BinaryData objects.
+//! PyBinaryData is the Python wrapper class defined below for the BinaryData class.
+//! It is exposed here as a global so helper functions can instantiate new BinaryData objects.
 boost::python::object PyBinaryData;
 
-// Compile-time mapping from integer types to numpy typenumbers
-template <typename T> struct numpy_typenums {};
-template <> struct numpy_typenums<libdvid::uint8> { static const int typenum = NPY_UINT8; };
-template <> struct numpy_typenums<libdvid::uint64> { static const int typenum = NPY_UINT64; };
-
+//! Helper function.
+//! Converts the given Json::Value into a Python dict.
 boost::python::dict convert_json_to_dict(Json::Value const & json_value)
 {
     using namespace boost::python;
@@ -38,6 +39,9 @@ boost::python::dict convert_json_to_dict(Json::Value const & json_value)
     return extract<dict>( json.attr("loads")( ss.str() ) );
 }
 
+//! Helper function.
+//! Converts the given Python object into a BinaryData object.
+//! The Python object must support the buffer protocol (e.g. str, bytearray).
 libdvid::BinaryDataPtr convert_python_value_to_binary_data(boost::python::object const & value)
 {
     using namespace libdvid;
@@ -58,12 +62,14 @@ libdvid::BinaryDataPtr convert_python_value_to_binary_data(boost::python::object
     return data;
 }
 
+//! Python wrapper function for DVIDNodeService::get_typeinfo()
 boost::python::dict python_get_typeinfo(libdvid::DVIDNodeService & nodeService, std::string datatype_name)
 {
     Json::Value value = nodeService.get_typeinfo(datatype_name);
     return convert_json_to_dict(value);
 }
 
+//! Python wrapper function for DVIDNodeService::put()
 void put_keyvalue(libdvid::DVIDNodeService & nodeService, std::string keyvalue, std::string key, boost::python::object & value)
 {
     using namespace libdvid;
@@ -80,6 +86,7 @@ void put_keyvalue(libdvid::DVIDNodeService & nodeService, std::string keyvalue, 
     nodeService.put(keyvalue, key, data );
 }
 
+//! Python wrapper function for DVIDNodeService::get()
 boost::python::object get_keyvalue(libdvid::DVIDNodeService & nodeService, std::string keyvalue, std::string key)
 {
     using namespace libdvid;
@@ -94,12 +101,15 @@ boost::python::object get_keyvalue(libdvid::DVIDNodeService & nodeService, std::
     return object(handle<>(py_str));
 }
 
+//! Python wrapper function for DVIDNodeService::get_json()
 boost::python::dict get_keyvalue_json(libdvid::DVIDNodeService & nodeService, std::string keyvalue, std::string key)
 {
     Json::Value value = nodeService.get_json(keyvalue, key);
     return convert_json_to_dict(value);
 }
 
+//! Python wrapper function for DVIDConnection::make_request().
+//! The payload_object must support the Python buffer protocol (e.g. str, bytearray).
 boost::python::tuple make_request( libdvid::DVIDConnection & connection,
                                    std::string endpoint,
                                    libdvid::ConnectionMethod method,
@@ -129,6 +139,123 @@ boost::python::tuple make_request( libdvid::DVIDConnection & connection,
     return make_tuple(status_code, object(handle<>(py_result_body_str )), err_msg);
 }
 
+//! This helper struct is specialized over integer types to provide a
+//! compile-time mapping from integer types to numpy typenumbers.
+template <typename T> struct numpy_typenums {};
+template <> struct numpy_typenums<libdvid::uint8> { static const int typenum = NPY_UINT8; };
+template <> struct numpy_typenums<libdvid::uint64> { static const int typenum = NPY_UINT64; };
+
+//! Declares a mapping between numpy typenumbers and the corresponding dtype names
+static boost::unordered_map<int, std::string> dtype_names =
+    boost::assign::map_list_of
+    (NPY_UINT8, "uint8")
+    (NPY_UINT64, "uint64");
+
+/*
+ * This struct contains a generic function get_volume() which can be used to
+ * retrieve ND data from DVID.  The struct is parameterized on the voxel_type
+ * and dimensionality of the volume to be retrieved.
+ *
+ * Type-specific functions like get_gray3D are implemented below as thin
+ * wrappers around get_volume, which does the real work.
+ */
+template <typename voxel_type, int N>
+struct GetVolumeHelper
+{
+    static const int numpy_typenum = numpy_typenums<voxel_type>::typenum;
+
+    typedef libdvid::DVIDVoxels<voxel_type, N> volume_type;
+    typedef volume_type get_volume_fn_signature( std::string datatype_instance,
+                                                 libdvid::Dims_t dims,
+                                                 std::vector<unsigned int> offset,
+                                                 bool throttle,
+                                                 bool compress,
+                                                 std::string roi );
+    typedef boost::function<get_volume_fn_signature> get_volume_fn_t;
+
+    //! Retrieve generic ND data from DVID.
+    //! See struct documentation above.
+    //!
+    //! \param get_volume_fn A function that can retrieve data of type volume_type.
+    static boost::python::object get_volume( std::string datatype_instance,
+                                             boost::python::object dims_tuple,
+                                             boost::python::object offset_tuple,
+                                             bool throttle,
+                                             bool compress,
+                                             boost::python::object roi_str,
+                                             get_volume_fn_t const & get_volume_fn )
+    {
+        using namespace boost::python;
+        using namespace libdvid;
+
+        // Extract roi from python string
+        std::string roi = "";
+        if (roi_str != object())
+        {
+            roi = extract<std::string>(roi_str);
+        }
+
+        // Extract dimensions from python list/tuple
+        libdvid::Dims_t dims;
+        typedef stl_input_iterator<Dims_t::value_type> dims_iter_t;
+        dims.assign( dims_iter_t(dims_tuple), dims_iter_t() );
+
+        // Extract offset from python list/tuple
+        typedef stl_input_iterator<unsigned int> offset_iter_t;
+        std::vector<unsigned int> offset;
+        offset.assign( offset_iter_t(offset_tuple), offset_iter_t() );
+
+        // Create our own BinaryData instance, managed in Python
+        object py_managed_bd = PyBinaryData();
+        BinaryData & managed_bd = extract<BinaryData&>(py_managed_bd);
+
+        // Retrieve the ND data
+        volume_type volume = get_volume_fn( datatype_instance, dims, offset, throttle, compress, roi );
+        BinaryDataPtr volume_data = volume.get_binary();
+
+        // Swap the retrieved data into our own (Python-managed) PyBinaryData object.
+        managed_bd.get_data().swap( volume_data->get_data() );
+
+        // Prepare the dims array for numpy to read.
+        Dims_t volume_dims = volume.get_dims();
+        std::vector<npy_intp> numpy_dims;
+        std::copy( volume_dims.begin(), volume_dims.end(), std::back_inserter(numpy_dims) );
+
+        // We will create a new array with the data from the existing PyBinaryData object (no copy).
+        // The basic idea is described in the following link, but can get away with a lot less code
+        // because boost-python already defined the new Python type for us (PyBinaryData).
+        // Also, this post is old so the particular API we're using here is slightly different.
+        // http://blog.enthought.com/python/numpy-arrays-with-pre-allocated-memory/
+        void const * raw_data = static_cast<void const*>(managed_bd.get_raw());
+        PyObject * array_object = PyArray_SimpleNewFromData( numpy_dims.size(),
+                                                             &numpy_dims[0],
+                                                             numpy_typenum,
+                                                             const_cast<void*>(raw_data) );
+        if (!array_object)
+        {
+            throw ErrMsg("Failed to create array from BinaryData!");
+        }
+        PyArrayObject * ndarray = reinterpret_cast<PyArrayObject *>( array_object );
+
+        // As described in the link above, assigning the 'base' pointer here ensures
+        //  that the memory is deallocated when the user is done with the ndarray.
+        int status = PyArray_SetBaseObject(ndarray, py_managed_bd.ptr());
+        if (status != 0)
+        {
+            throw ErrMsg("Failed to set array base object!");
+        }
+        // PyArray_SetBaseObject *steals* the reference, so we need to INCREF here
+        //  to make sure the binary data object isn't destroyed when we return.
+        Py_INCREF(py_managed_bd.ptr());
+
+        // Return the new array.
+        return object(handle<>(array_object));
+    }
+};
+template <typename voxel_type, int N>
+const int GetVolumeHelper<voxel_type, N>::numpy_typenum;
+
+//! Python wrapper function for DVIDNodeService::get_gray3D()
 boost::python::object get_gray3D( libdvid::DVIDNodeService & nodeService,
                                   std::string datatype_instance,
                                   boost::python::object dims_tuple,
@@ -140,103 +267,170 @@ boost::python::object get_gray3D( libdvid::DVIDNodeService & nodeService,
     using namespace boost::python;
     using namespace libdvid;
 
-    std::string roi = "";
-    if (roi_str != object())
-    {
-        roi = extract<std::string>(roi_str);
-    }
-
-    libdvid::Dims_t dims;
-    typedef stl_input_iterator<Dims_t::value_type> dims_iter_t;
-    dims.assign( dims_iter_t(dims_tuple), dims_iter_t() );
-
-    typedef stl_input_iterator<unsigned int> offset_iter_t;
-    std::vector<unsigned int> offset;
-    offset.assign( offset_iter_t(offset_tuple), offset_iter_t() );
-
-    // Create our own BinaryData instance, managed in Python
-    object py_managed_bd = PyBinaryData();
-    BinaryData & managed_bd = extract<BinaryData&>(py_managed_bd);
-
-    Grayscale3D volume = nodeService.get_gray3D( datatype_instance, dims, offset, throttle, compress, roi );
-    BinaryDataPtr volume_data = volume.get_binary();
-
-    // Swap the data into our managed object.
-    managed_bd.get_data().swap( volume_data->get_data() );
-
-    // Create a new array with the data from the existing PyBinaryData object (no copy).
-    // The basic idea is described in the following link, but can get away with a lot less code
-    // because boost-python already defined the new Python type for us (PyBinaryData).
-    // Also, this post is old so the particular API we're using here is slightly different.
-    // http://blog.enthought.com/python/numpy-arrays-with-pre-allocated-memory/
-    Dims_t volume_dims = volume.get_dims();
-    std::vector<npy_intp> numpy_dims;
-    std::copy( volume_dims.begin(), volume_dims.end(), std::back_inserter(numpy_dims) );
-    void const * raw_data = static_cast<void const*>(managed_bd.get_raw());
-
-    PyObject * array_object = PyArray_SimpleNewFromData( numpy_dims.size(),
-                                                         &numpy_dims[0],
-                                                         numpy_typenums<uint8>::typenum,
-                                                         const_cast<void*>(raw_data) );
-    if (!array_object)
-    {
-        throw ErrMsg("Failed to create array from BinaryData!");
-    }
-    Py_INCREF(py_managed_bd.ptr());
-    PyArrayObject * ndarray = reinterpret_cast<PyArrayObject *>( array_object );
-
-    // As described in the link above, assigning the 'base' pointer here ensures
-    //  that the memory is deallocated when the user is done with the ndarray.
-    int status = PyArray_SetBaseObject(ndarray, py_managed_bd.ptr());
-    if (status != 0)
-    {
-        throw ErrMsg("Failed to set array base object!");
-    }
-    return object(handle<>(array_object));
+    return GetVolumeHelper<uint8, 3>::get_volume(
+        datatype_instance,
+        dims_tuple,
+        offset_tuple,
+        throttle,
+        compress,
+        roi_str,
+        boost::bind(&DVIDNodeService::get_gray3D, boost::ref(nodeService), _1, _2, _3, _4, _5, _6) );
 }
 
-void put_gray3D( libdvid::DVIDNodeService & nodeService,
-                 std::string datatype_instance,
-                 boost::python::object ndarray,
-                 boost::python::object offset_tuple,
-                 bool throttle=true,
-                 bool compress=false )
+//! Python wrapper function for DVIDNodeService::get_labels3D()
+boost::python::object get_labels3D( libdvid::DVIDNodeService & nodeService,
+                                    std::string datatype_instance,
+                                    boost::python::object dims_tuple,
+                                    boost::python::object offset_tuple,
+                                    bool throttle,
+                                    bool compress,
+                                    boost::python::object roi_str )
 {
     using namespace boost::python;
     using namespace libdvid;
 
-    typedef stl_input_iterator<unsigned int> offset_iter_t;
-    std::vector<unsigned int> offset;
-    offset.assign( offset_iter_t(offset_tuple), offset_iter_t() );
-
-    if (str(ndarray.attr("dtype")) != "uint8")
-    {
-        std::string dtype = extract<std::string>(str(ndarray.attr("dtype")));
-        throw ErrMsg("Volume has wrong dtype.  Expected uint8, got " + dtype);
-    }
-    if (ndarray.attr("ndim") != 3)
-    {
-        std::string shape = extract<std::string>(str(ndarray.attr("shape")));
-        throw ErrMsg("Volume is not exactly 3D.  Shape is " + shape);
-    }
-    if (!ndarray.attr("flags")["C_CONTIGUOUS"])
-    {
-        throw ErrMsg("Volume is not C_CONTIGUOUS");
-    }
-
-    object shape = ndarray.attr("shape");
-    typedef stl_input_iterator<Dims_t::value_type> shape_iter_t;
-    Dims_t dims;
-    dims.assign( shape_iter_t(shape), shape_iter_t() );
-
-    PyArrayObject * array_object = reinterpret_cast<PyArrayObject *>( ndarray.ptr() );
-    Grayscale3D grayscale_vol( static_cast<uint8 const *>( PyArray_DATA(array_object) ),
-                               extract<int>(ndarray.attr("size")) * sizeof(Grayscale3D::voxel_type),
-                               dims );
-    nodeService.put_gray3D( datatype_instance, grayscale_vol, offset, throttle, compress );
+    return GetVolumeHelper<uint64, 3>::get_volume(
+        datatype_instance,
+        dims_tuple,
+        offset_tuple,
+        throttle,
+        compress,
+        roi_str,
+        boost::bind(&DVIDNodeService::get_labels3D, boost::ref(nodeService), _1, _2, _3, _4, _5, _6) );
 }
 
 
+/*
+ * This struct contains a generic function put_volume() which can be used to
+ * send ND data to DVID.  The struct is parameterized on the voxel_type and
+ * dimensionality of the volume to be sent.
+ *
+ * Type-specific functions like put_gray3D are implemented below as thin
+ * wrappers around put_volume, which does the real work.
+ */
+template <typename voxel_type, int N>
+struct PutVolumeHelper
+{
+    static const int numpy_typenum = numpy_typenums<voxel_type>::typenum;
+
+    typedef libdvid::DVIDVoxels<voxel_type, N> volume_type;
+    typedef void put_volume_fn_signature( std::string datatype_instance,
+                                          volume_type & volume,
+                                          std::vector<unsigned int> offset,
+                                          bool throttle,
+                                          bool compress );
+    typedef boost::function<put_volume_fn_signature> put_volume_fn_t;
+
+    //! Send generic ND data to DVID.
+    //! See struct documentation above.
+    //!
+    //! \param put_volume_fn A function that can retrieve data of type volume_type.
+    static void put_volume( std::string datatype_instance,
+                            boost::python::object ndarray,
+                            boost::python::object offset_tuple,
+                            bool throttle,
+                            bool compress,
+                            put_volume_fn_t const & put_volume_fn )
+    {
+        using namespace boost::python;
+        using namespace libdvid;
+
+        // Verify ndarray.dtype
+        std::string dtype = extract<std::string>(str(ndarray.attr("dtype")));
+        if (dtype != dtype_names[numpy_typenum])
+        {
+            std::ostringstream ssMsg;
+            ssMsg << "Volume has wrong dtype.  Expected " << dtype_names[numpy_typenum] << ", got " << dtype;
+            throw ErrMsg(ssMsg.str());
+        }
+
+        // Verify ndarray dimensionality.
+        if (ndarray.attr("ndim") != N)
+        {
+            std::string shape = extract<std::string>(str(ndarray.attr("shape")));
+            std::ostringstream ssMsg;
+            ssMsg << "Volume is not exactly " << N << "D.  Shape is " << shape;
+            throw ErrMsg( ssMsg.str() );
+        }
+        // Verify ndarray memory order
+        if (!ndarray.attr("flags")["C_CONTIGUOUS"])
+        {
+            throw ErrMsg("Volume is not C_CONTIGUOUS");
+        }
+
+        // Extract dimensions from python list/tuple
+        typedef stl_input_iterator<unsigned int> offset_iter_t;
+        std::vector<unsigned int> offset;
+        offset.assign( offset_iter_t(offset_tuple), offset_iter_t() );
+
+        // Extract dims from ndarray.shape
+        object shape = ndarray.attr("shape");
+        typedef stl_input_iterator<Dims_t::value_type> shape_iter_t;
+        Dims_t dims;
+        dims.assign( shape_iter_t(shape), shape_iter_t() );
+
+        // Extract the voxel count
+        int voxel_count = extract<int>(ndarray.attr("size"));
+
+        // Obtain a pointer to the array's data
+        PyArrayObject * array_object = reinterpret_cast<PyArrayObject *>( ndarray.ptr() );
+        voxel_type const * voxel_data = static_cast<voxel_type const *>( PyArray_DATA(array_object) );
+
+        // Create DVIDVoxels<> from ndarray data
+        // FIXME: This copies the data.  Is that really necessary?
+        volume_type grayscale_vol( voxel_data, voxel_count, dims );
+
+        // Send to DVID
+        put_volume_fn( datatype_instance, grayscale_vol, offset, throttle, compress );
+    }
+};
+template <typename voxel_type, int N>
+const int PutVolumeHelper<voxel_type, N>::numpy_typenum;
+
+//! Python wrapper function for DVIDNodeService::put_gray3D()
+void put_gray3D( libdvid::DVIDNodeService & nodeService,
+                 std::string datatype_instance,
+                 boost::python::object ndarray,
+                 boost::python::object offset_tuple,
+                 bool throttle,
+                 bool compress)
+{
+    using namespace boost::python;
+    using namespace libdvid;
+
+    PutVolumeHelper<uint8, 3>::put_volume(
+        datatype_instance,
+        ndarray,
+        offset_tuple,
+        throttle,
+        compress,
+        boost::bind(&DVIDNodeService::put_gray3D, boost::ref(nodeService), _1, _2, _3, _4, _5) );
+}
+
+//! Python wrapper function for DVIDNodeService::put_labels3D()
+void put_labels3D( libdvid::DVIDNodeService & nodeService,
+                 std::string datatype_instance,
+                 boost::python::object ndarray,
+                 boost::python::object offset_tuple,
+                 bool throttle,
+                 bool compress)
+{
+    using namespace boost::python;
+    using namespace libdvid;
+
+    PutVolumeHelper<uint64, 3>::put_volume(
+        datatype_instance,
+        ndarray,
+        offset_tuple,
+        throttle,
+        compress,
+        boost::bind(&DVIDNodeService::put_labels3D, boost::ref(nodeService), _1, _2, _3, _4, _5, "") );
+}
+
+/*
+ * Initialize the Python module (_dvid_python)
+ * This cpp file should be built as _dvid_python.so
+ */
 BOOST_PYTHON_MODULE(_dvid_python)
 {
     using namespace libdvid;
@@ -245,13 +439,7 @@ BOOST_PYTHON_MODULE(_dvid_python)
     // http://docs.scipy.org/doc/numpy/reference/c-api.array.html#importing-the-api
     import_array()
 
-    enum_<ConnectionMethod>("ConnectionMethod")
-        .value("GET", GET)
-        .value("POST", POST)
-        .value("PUT", PUT)
-        .value("DELETE", DELETE)
-    ;
-
+    // DVIDConnection python class definition
     class_<DVIDConnection>("DVIDConnection", init<std::string>())
         .def("make_request", &make_request,
                              ( arg("connection"), arg("endpoint"), arg("method"), arg("payload")=object(), arg("timeout")=DVIDConnection::DEFAULT_TIMEOUT ))
@@ -259,13 +447,16 @@ BOOST_PYTHON_MODULE(_dvid_python)
         .def("get_uri_root", &DVIDConnection::get_uri_root)
     ;
 
-    PyBinaryData = class_<BinaryData, BinaryDataPtr>("BinaryData", no_init)
-        .def("__init__", make_constructor<BinaryDataPtr()>(&BinaryData::create_binary_data))
+    enum_<ConnectionMethod>("ConnectionMethod")
+        .value("GET", GET)
+        .value("POST", POST)
+        .value("PUT", PUT)
+        .value("DELETE", DELETE)
     ;
 
+    // DVIDNodeService python class definition
     class_<DVIDNodeService>("DVIDNodeService", init<std::string, UUID>())
         .def("get_typeinfo", &python_get_typeinfo)
-        .def("create_labelblk", &DVIDNodeService::create_labelblk)
         .def("create_graph", &DVIDNodeService::create_graph)
         
         // keyvalue
@@ -277,9 +468,22 @@ BOOST_PYTHON_MODULE(_dvid_python)
         // grayscale
         .def("create_grayscale8", &DVIDNodeService::create_grayscale8)
         .def("get_gray3D", &get_gray3D,
-                           ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object()))
+            ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object()))
         .def("put_gray3D", &put_gray3D,
-                           ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false))
+            ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false))
+
+        // labels
+       .def("create_labelblk", &DVIDNodeService::create_labelblk)
+       .def("get_labels3D", &get_labels3D,
+            ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object()))
+       .def("put_labels3D", &put_labels3D,
+            ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false))
+    ;
+
+    // Define a python version of BinaryData, and keep a global
+    //  reference to it so we can instantiate it ourselves.
+    PyBinaryData = class_<BinaryData, BinaryDataPtr>("BinaryData", no_init)
+        .def("__init__", make_constructor<BinaryDataPtr()>(&BinaryData::create_binary_data))
     ;
 
 }

--- a/python/src/libdvid_python.cpp
+++ b/python/src/libdvid_python.cpp
@@ -2,6 +2,9 @@
 #include <boost/python.hpp>
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+// http://docs.scipy.org/doc/numpy/reference/c-api.array.html#importing-the-api
+#define PY_ARRAY_UNIQUE_SYMBOL libdvid_PYTHON_BINDINGS
 #include <numpy/arrayobject.h>
 
 #include <sstream>
@@ -112,6 +115,9 @@ BOOST_PYTHON_MODULE(_dvid_python)
 {
     using namespace libdvid;
     using namespace boost::python;
+
+    // http://docs.scipy.org/doc/numpy/reference/c-api.array.html#importing-the-api
+    import_array()
 
     enum_<ConnectionMethod>("ConnectionMethod")
         .value("GET", GET)

--- a/python/src/libdvid_python.cpp
+++ b/python/src/libdvid_python.cpp
@@ -1,10 +1,5 @@
 #include <Python.h>
 #include <boost/python.hpp>
-#include <boost/python/stl_iterator.hpp>
-#include <boost/bind.hpp>
-#include <boost/function.hpp>
-#include <boost/unordered_map.hpp>
-#include <boost/assign/list_of.hpp>
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
@@ -13,7 +8,6 @@
 #include <numpy/arrayobject.h>
 
 #include <sstream>
-#include <algorithm>
 
 #include "BinaryData.h"
 #include "DVIDConnection.h"
@@ -22,10 +16,6 @@
 #include "DVIDException.h"
 
 #include "converters.hpp"
-
-//! PyBinaryData is the Python wrapper class defined below for the BinaryData class.
-//! It is exposed here as a global so helper functions can instantiate new BinaryData objects.
-boost::python::object PyBinaryData;
 
 //! Helper function.
 //! Converts the given Json::Value into a Python dict.
@@ -168,188 +158,6 @@ boost::python::tuple make_request( libdvid::DVIDConnection & connection,
     return make_tuple(status_code, object(handle<>(py_result_body_str )), err_msg);
 }
 
-//! This helper struct is specialized over integer types to provide a
-//! compile-time mapping from integer types to numpy typenumbers.
-template <typename T> struct numpy_typenums {};
-template <> struct numpy_typenums<libdvid::uint8> { static const int typenum = NPY_UINT8; };
-template <> struct numpy_typenums<libdvid::uint64> { static const int typenum = NPY_UINT64; };
-
-//! Declares a mapping between numpy typenumbers and the corresponding dtype names
-static boost::unordered_map<int, std::string> dtype_names =
-    boost::assign::map_list_of
-    (NPY_UINT8, "uint8")
-    (NPY_UINT64, "uint64");
-
-/*
- * Converts the given DVIDVoxels object into a numpy array.
- * NOTE:The ndarray will *steal* the data from the DVIDVoxels object.
- */
-template <class VolumeType>
-boost::python::object convert_volume_to_ndarray( VolumeType & volume )
-{
-    using namespace boost::python;
-    using namespace libdvid;
-
-    typedef typename VolumeType::voxel_type voxel_type;
-
-    BinaryDataPtr volume_data = volume.get_binary();
-
-    // Create our own BinaryData instance, managed in Python
-    object py_managed_bd = PyBinaryData();
-    BinaryData & managed_bd = extract<BinaryData&>(py_managed_bd);
-
-    // Swap the retrieved data into our own (Python-managed) PyBinaryData object.
-    managed_bd.get_data().swap( volume_data->get_data() );
-
-    // Copy dims to type numpy expects.
-    std::vector<npy_intp> numpy_dims( volume.get_dims().begin(), volume.get_dims().end() );
-
-    // We will create a new array with the data from the existing PyBinaryData object (no copy).
-    // The basic idea is described in the following link, but can get away with a lot less code
-    // because boost-python already defined the new Python type for us (PyBinaryData).
-    // Also, this post is old so the particular API we're using here is slightly different.
-    // http://blog.enthought.com/python/numpy-arrays-with-pre-allocated-memory/
-    void const * raw_data = static_cast<void const*>(managed_bd.get_raw());
-    PyObject * array_object = PyArray_SimpleNewFromData( numpy_dims.size(),
-                                                         &numpy_dims[0],
-                                                         numpy_typenums<voxel_type>::typenum,
-                                                         const_cast<void*>(raw_data) );
-    if (!array_object)
-    {
-        throw ErrMsg("Failed to create array from BinaryData!");
-    }
-    PyArrayObject * ndarray = reinterpret_cast<PyArrayObject *>( array_object );
-
-    // As described in the link above, assigning the 'base' pointer here ensures
-    //  that the memory is deallocated when the user is done with the ndarray.
-    int status = PyArray_SetBaseObject(ndarray, py_managed_bd.ptr());
-    if (status != 0)
-    {
-        throw ErrMsg("Failed to set array base object!");
-    }
-    // PyArray_SetBaseObject *steals* the reference, so we need to INCREF here
-    //  to make sure the binary data object isn't destroyed when we return.
-    incref(py_managed_bd.ptr());
-
-    // Return the new array.
-    return object(handle<>(array_object));
-}
-
-//! Python wrapper function for DVIDNodeService::get_gray3D()
-boost::python::object get_gray3D( libdvid::DVIDNodeService & nodeService,
-                                  std::string datatype_instance,
-                                  std::vector<unsigned int> dims,
-                                  std::vector<unsigned int> offset,
-                                  bool throttle,
-                                  bool compress,
-                                  std::string roi )
-{
-    using namespace libdvid;
-    DVIDVoxels<uint8, 3> volume = nodeService.get_gray3D(datatype_instance, dims, offset, throttle, compress, roi);
-    return convert_volume_to_ndarray( volume );
-}
-
-//! Python wrapper function for DVIDNodeService::get_labels3D()
-boost::python::object get_labels3D( libdvid::DVIDNodeService & nodeService,
-                                    std::string datatype_instance,
-                                    std::vector<unsigned int> dims,
-                                    std::vector<unsigned int> offset,
-                                    bool throttle,
-                                    bool compress,
-                                    std::string roi )
-{
-    using namespace libdvid;
-    DVIDVoxels<uint64, 3> volume = nodeService.get_labels3D(datatype_instance, dims, offset, throttle, compress, roi);
-    return convert_volume_to_ndarray( volume );
-}
-
-
-/*
- * Converts the given numpy ndarray object into a DVIDVoxels object.
- * NOTE: The data from the ndarray is *copied* into the new DVIDVoxels object.
- */
-template <class VolumeType>
-VolumeType convert_ndarray_to_volume( boost::python::object ndarray )
-{
-    using namespace boost::python;
-    using namespace libdvid;
-
-    typedef typename VolumeType::voxel_type voxel_type;
-
-    // Verify ndarray.dtype
-    std::string dtype = extract<std::string>(str(ndarray.attr("dtype")));
-    const int numpy_typenum = numpy_typenums<voxel_type>::typenum;
-    if (dtype != dtype_names[numpy_typenum])
-    {
-        std::ostringstream ssMsg;
-        ssMsg << "Volume has wrong dtype.  Expected " << dtype_names[numpy_typenum] << ", got " << dtype;
-        throw ErrMsg(ssMsg.str());
-    }
-
-    // Verify ndarray dimensionality.
-    int ndarray_ndim = extract<int>(ndarray.attr("ndim"));
-    if (ndarray_ndim != VolumeType::num_dims)
-    {
-        std::string shape = extract<std::string>(str(ndarray.attr("shape")));
-        std::ostringstream ssMsg;
-        ssMsg << "Volume is not exactly " << VolumeType::num_dims << "D.  Shape is " << shape;
-        throw ErrMsg( ssMsg.str() );
-    }
-    // Verify ndarray memory order
-    if (!ndarray.attr("flags")["C_CONTIGUOUS"])
-    {
-        throw ErrMsg("Volume is not C_CONTIGUOUS");
-    }
-
-    // Extract dims from ndarray.shape
-    object shape = ndarray.attr("shape");
-    typedef stl_input_iterator<Dims_t::value_type> shape_iter_t;
-    Dims_t dims;
-    dims.assign( shape_iter_t(shape), shape_iter_t() );
-
-    // Extract the voxel count
-    int voxel_count = extract<int>(ndarray.attr("size"));
-
-    // Obtain a pointer to the array's data
-    PyArrayObject * array_object = reinterpret_cast<PyArrayObject *>( ndarray.ptr() );
-    voxel_type const * voxel_data = static_cast<voxel_type const *>( PyArray_DATA(array_object) );
-
-    // Create DVIDVoxels<> from ndarray data
-    // FIXME: This copies the data.  Is that really necessary?
-    VolumeType grayscale_vol( voxel_data, voxel_count, dims );
-    return grayscale_vol;
-}
-
-//! Python wrapper function for DVIDNodeService::put_gray3D()
-void put_gray3D( libdvid::DVIDNodeService & nodeService,
-                 std::string datatype_instance,
-                 boost::python::object ndarray,
-                 std::vector<unsigned int> offset,
-                 bool throttle,
-                 bool compress)
-{
-    using namespace boost::python;
-    using namespace libdvid;
-
-    Grayscale3D volume = convert_ndarray_to_volume<Grayscale3D>( ndarray );
-    nodeService.put_gray3D( datatype_instance, volume, offset, throttle, compress );
-}
-
-//! Python wrapper function for DVIDNodeService::put_labels3D()
-void put_labels3D( libdvid::DVIDNodeService & nodeService,
-                 std::string datatype_instance,
-                 boost::python::object ndarray,
-                 std::vector<unsigned int> offset,
-                 bool throttle,
-                 bool compress)
-{
-    using namespace boost::python;
-    using namespace libdvid;
-
-    Labels3D volume = convert_ndarray_to_volume<Labels3D>( ndarray );
-    nodeService.put_labels3D( datatype_instance, volume, offset, throttle, compress );
-}
-
 /*
  * Initialize the Python module (_dvid_python)
  * This cpp file should be built as _dvid_python.so
@@ -362,9 +170,16 @@ BOOST_PYTHON_MODULE(_dvid_python)
     // http://docs.scipy.org/doc/numpy/reference/c-api.array.html#importing-the-api
     import_array()
 
-    // Custom converters.
+    // Register custom Python -> C++ converters.
     libdvid::python::std_vector_from_python_iterable<unsigned int>();
     libdvid::python::std_string_from_python_none(); // None -> std::string("")
+    libdvid::python::ndarray_to_volume<Grayscale3D>();
+    libdvid::python::ndarray_to_volume<Labels3D>();
+
+    // Register custom C++ -> Python converters.
+    to_python_converter<BinaryDataPtr, libdvid::python::binary_data_ptr_to_python_str>();
+    to_python_converter<Grayscale3D, libdvid::python::volume_to_ndarray<Grayscale3D> >();
+    to_python_converter<Labels3D, libdvid::python::volume_to_ndarray<Labels3D> >();
 
     // DVIDConnection python class definition
     class_<DVIDConnection>("DVIDConnection", init<std::string>())
@@ -386,6 +201,13 @@ BOOST_PYTHON_MODULE(_dvid_python)
         .def("create_new_repo", &DVIDServerService::create_new_repo)
     ;
 
+    // For overloaded functions, boost::python needs help figuring out which one we're aiming for.
+    // These function pointers specify the ones we want.
+    Grayscale3D (DVIDNodeService::*get_gray3D)(std::string, Dims_t, std::vector<unsigned int>, bool, bool, std::string) = &DVIDNodeService::get_gray3D;
+    Labels3D (DVIDNodeService::*get_labels3D)(std::string, Dims_t, std::vector<unsigned int>, bool, bool, std::string) = &DVIDNodeService::get_labels3D;
+    void (DVIDNodeService::*put_gray3D)(std::string, Grayscale3D const&, std::vector<unsigned int>, bool, bool) = &DVIDNodeService::put_gray3D;
+    void (DVIDNodeService::*put_labels3D)(std::string, Labels3D const&, std::vector<unsigned int>, bool, bool, std::string) = &DVIDNodeService::put_labels3D;
+
     // DVIDNodeService python class definition
     class_<DVIDNodeService>("DVIDNodeService", init<std::string, UUID>())
         .def("get_typeinfo", &python_get_typeinfo)
@@ -400,23 +222,20 @@ BOOST_PYTHON_MODULE(_dvid_python)
 
         // grayscale
         .def("create_grayscale8", &DVIDNodeService::create_grayscale8)
-        .def("get_gray3D", &get_gray3D,
-            ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object()))
-        .def("put_gray3D", &put_gray3D,
+        .def("get_gray3D", get_gray3D,
+            ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
+        .def("put_gray3D", put_gray3D,
             ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false))
 
         // labels
        .def("create_labelblk", &DVIDNodeService::create_labelblk)
-       .def("get_labels3D", &get_labels3D,
-            ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object()))
-       .def("put_labels3D", &put_labels3D,
-            ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false))
+       .def("get_labels3D", get_labels3D,
+            ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
+       .def("put_labels3D", put_labels3D,
+            ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
     ;
 
-    // Define a python version of BinaryData, and keep a global
+    // Define a python version of BinaryDataHolder, and keep a global
     //  reference to it so we can instantiate it ourselves.
-    PyBinaryData = class_<BinaryData, BinaryDataPtr>("BinaryData", no_init)
-        .def("__init__", make_constructor<BinaryDataPtr()>(&BinaryData::create_binary_data))
-    ;
-
+    libdvid::python::PyBinaryDataHolder = class_<libdvid::python::BinaryDataHolder>("BinaryDataHolder");
 }

--- a/python/src/libdvid_python.cpp
+++ b/python/src/libdvid_python.cpp
@@ -134,7 +134,7 @@ BOOST_PYTHON_MODULE(_dvid_python)
 
     class_<DVIDConnection>("DVIDConnection", init<std::string>())
         .def("make_request", &make_request,
-                            ( arg("connection"), arg("endpoint"), arg("method"), arg("payload")=str(), arg("timeout")=DVIDConnection::DEFAULT_TIMEOUT ))
+                             ( arg("connection"), arg("endpoint"), arg("method"), arg("payload")=object(), arg("timeout")=DVIDConnection::DEFAULT_TIMEOUT ))
         .def("get_addr", &DVIDConnection::get_addr)
         .def("get_uri_root", &DVIDConnection::get_uri_root)
     ;

--- a/python/src/libdvid_python.cpp
+++ b/python/src/libdvid_python.cpp
@@ -175,11 +175,15 @@ BOOST_PYTHON_MODULE(_dvid_python)
     libdvid::python::std_string_from_python_none(); // None -> std::string("")
     libdvid::python::ndarray_to_volume<Grayscale3D>();
     libdvid::python::ndarray_to_volume<Labels3D>();
+    libdvid::python::ndarray_to_volume<Grayscale2D>();
+    libdvid::python::ndarray_to_volume<Labels2D>();
 
     // Register custom C++ -> Python converters.
     to_python_converter<BinaryDataPtr, libdvid::python::binary_data_ptr_to_python_str>();
     to_python_converter<Grayscale3D, libdvid::python::volume_to_ndarray<Grayscale3D> >();
     to_python_converter<Labels3D, libdvid::python::volume_to_ndarray<Labels3D> >();
+    to_python_converter<Grayscale2D, libdvid::python::volume_to_ndarray<Grayscale2D> >();
+    to_python_converter<Labels2D, libdvid::python::volume_to_ndarray<Labels2D> >();
 
     // DVIDConnection python class definition
     class_<DVIDConnection>("DVIDConnection", init<std::string>())
@@ -233,6 +237,16 @@ BOOST_PYTHON_MODULE(_dvid_python)
             ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
        .def("put_labels3D", put_labels3D,
             ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
+
+        // 2D slices
+        .def("get_tile_slice", &DVIDNodeService::get_tile_slice)
+        .def("get_tile_slice_binary", &DVIDNodeService::get_tile_slice_binary)
+    ;
+
+    enum_<Slice2D>("Slice2D")
+        .value("XY", XY)
+        .value("XZ", XZ)
+        .value("YZ", YZ)
     ;
 
     // Define a python version of BinaryDataHolder, and keep a global

--- a/python/src/libdvid_python.cpp
+++ b/python/src/libdvid_python.cpp
@@ -69,6 +69,32 @@ boost::python::dict python_get_typeinfo(libdvid::DVIDNodeService & nodeService, 
     return convert_json_to_dict(value);
 }
 
+//! Python wrapper function for DVIDNodeService::custom_request()
+boost::python::object custom_request( libdvid::DVIDNodeService & nodeService,
+                                      std::string endpoint,
+                                      boost::python::object payload_object,
+                                      libdvid::ConnectionMethod method )
+{
+    using namespace libdvid;
+    using namespace boost::python;
+
+    BinaryDataPtr payload_data;
+
+    // Check for None
+    if (payload_object == object())
+    {
+        payload_data = BinaryData::create_binary_data();
+    }
+    else
+    {
+        payload_data = convert_python_value_to_binary_data( payload_object );
+    }
+
+    BinaryDataPtr results = nodeService.custom_request(endpoint, payload_data, method);
+    PyObject * py_result_body_str = PyString_FromStringAndSize( results->get_data().c_str(), results->get_data().size() );
+    return object(handle<>(py_result_body_str));
+}
+
 //! Python wrapper function for DVIDNodeService::put()
 void put_keyvalue(libdvid::DVIDNodeService & nodeService, std::string keyvalue, std::string key, boost::python::object & value)
 {
@@ -458,6 +484,7 @@ BOOST_PYTHON_MODULE(_dvid_python)
     class_<DVIDNodeService>("DVIDNodeService", init<std::string, UUID>())
         .def("get_typeinfo", &python_get_typeinfo)
         .def("create_graph", &DVIDNodeService::create_graph)
+        .def("custom_request", &custom_request)
         
         // keyvalue
         .def("create_keyvalue", &DVIDNodeService::create_keyvalue)

--- a/python/src/libdvid_python.cpp
+++ b/python/src/libdvid_python.cpp
@@ -82,6 +82,12 @@ boost::python::object get_keyvalue(libdvid::DVIDNodeService & nodeService, std::
     return object(handle<>(py_str));
 }
 
+boost::python::dict get_keyvalue_json(libdvid::DVIDNodeService & nodeService, std::string keyvalue, std::string key)
+{
+    Json::Value value = nodeService.get_json(keyvalue, key);
+    return convert_json_to_dict(value);
+}
+
 boost::python::tuple make_request( libdvid::DVIDConnection & connection,
                                    std::string endpoint,
                                    libdvid::ConnectionMethod method,
@@ -143,6 +149,7 @@ BOOST_PYTHON_MODULE(_dvid_python)
         .def("create_keyvalue", &DVIDNodeService::create_keyvalue)
         .def("put", &put_keyvalue)
         .def("get", &get_keyvalue)
+        .def("get_json", &get_keyvalue_json)
     ;
 
 }

--- a/python/src/libdvid_python.cpp
+++ b/python/src/libdvid_python.cpp
@@ -1,0 +1,98 @@
+#include <Python.h>
+#include <boost/python.hpp>
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+#include <sstream>
+
+#include "DVIDNodeService.h"
+#include "DVIDException.h"
+
+boost::python::dict convert_json_to_dict(Json::Value const & json_value)
+{
+    using namespace boost::python;
+    
+    // For now, easiest thing to do is just export as 
+    //  string and re-parse via python's json module.
+    std::ostringstream ss;
+    ss << json_value;
+    
+    object json = import("json");
+    return extract<dict>( json.attr("loads")( ss.str() ) );
+}
+
+libdvid::BinaryDataPtr convert_python_value_to_binary_data(boost::python::object const & value)
+{
+    using namespace libdvid;
+    using namespace boost::python;
+
+    PyObject* py_value = value.ptr();
+    if (!PyObject_CheckBuffer(py_value))
+    {
+        std::string value_str = extract<std::string>(str(value));
+        throw ErrMsg("Value is not a buffer: " + value_str);
+    }
+    Py_buffer py_buffer;
+    PyObject_GetBuffer(py_value, &py_buffer, PyBUF_SIMPLE);
+
+    // Copy buffer into BinaryData
+    BinaryDataPtr data = BinaryData::create_binary_data(static_cast<char*>(py_buffer.buf), py_buffer.len);
+    PyBuffer_Release(&py_buffer);
+    return data;
+}
+
+boost::python::dict python_get_typeinfo(libdvid::DVIDNodeService & nodeService, std::string datatype_name)
+{
+    Json::Value value = nodeService.get_typeinfo(datatype_name);
+    return convert_json_to_dict(value);
+}
+
+void put_keyvalue(libdvid::DVIDNodeService & nodeService, std::string keyvalue, std::string key, boost::python::object & value)
+{
+    using namespace libdvid;
+
+    BinaryDataPtr data;
+    try
+    {
+        data = convert_python_value_to_binary_data(value);
+    }
+    catch (ErrMsg const & ex)
+    {
+        throw ErrMsg("Writing to key '" + keyvalue + "/" + key + "' failed: " + ex.what());
+    }
+    nodeService.put(keyvalue, key, data );
+}
+
+boost::python::object get_keyvalue(libdvid::DVIDNodeService & nodeService, std::string keyvalue, std::string key)
+{
+    using namespace libdvid;
+    using namespace boost::python;
+
+    // Request value
+    BinaryDataPtr value = nodeService.get(keyvalue, key);
+
+    // Copy into a python buffer object
+    // Is there a way to avoid this copy?
+    PyObject * py_str = PyString_FromStringAndSize( value->get_data().c_str(), value->get_data().size() );
+    return object(handle<>(py_str));
+}
+
+BOOST_PYTHON_MODULE(_dvid_python)
+{
+    using namespace libdvid;
+    using namespace boost::python;
+
+    class_<DVIDNodeService>("DVIDNodeService", init<std::string, UUID>())
+        .def("get_typeinfo", &python_get_typeinfo)
+        .def("create_grayscale8", &DVIDNodeService::create_grayscale8)
+        .def("create_labelblk", &DVIDNodeService::create_labelblk)
+        .def("create_graph", &DVIDNodeService::create_graph)
+        
+        // keyvalue
+        .def("create_keyvalue", &DVIDNodeService::create_keyvalue)
+        .def("put", &put_keyvalue)
+        .def("get", &get_keyvalue)
+    ;
+
+}

--- a/python/src/libdvid_python.cpp
+++ b/python/src/libdvid_python.cpp
@@ -17,6 +17,7 @@
 
 #include "BinaryData.h"
 #include "DVIDConnection.h"
+#include "DVIDServerService.h"
 #include "DVIDNodeService.h"
 #include "DVIDException.h"
 
@@ -478,6 +479,11 @@ BOOST_PYTHON_MODULE(_dvid_python)
         .value("POST", POST)
         .value("PUT", PUT)
         .value("DELETE", DELETE)
+    ;
+
+    // DVIDServerService python class definition
+    class_<DVIDServerService>("DVIDServerService", init<std::string>())
+        .def("create_new_repo", &DVIDServerService::create_new_repo)
     ;
 
     // DVIDNodeService python class definition

--- a/python/tests/_test_utils.py
+++ b/python/tests/_test_utils.py
@@ -1,0 +1,35 @@
+import os
+import httplib
+import json
+
+from libdvid import DVIDConnection, ConnectionMethod
+TEST_DVID_SERVER = os.getenv("TEST_DVID_SERVER", "127.0.0.1:8000")
+
+def get_testrepo_root_uuid():
+    connection = DVIDConnection(TEST_DVID_SERVER)
+    status, body, error_message = connection.make_request( "/repos/info", ConnectionMethod.GET)
+    assert status == httplib.OK, "Request for /repos/info returned status {}".format( status )
+    assert error_message == ""
+    repos_info = json.loads(body)
+    test_repos = filter( lambda (uuid, repo_info): repo_info['Alias'] == 'testrepo', 
+                         repos_info.items() )
+    if test_repos:
+        uuid = test_repos[0][0]
+        return str(uuid)
+    else:
+        from libdvid import DVIDServerService
+        server = DVIDServerService(TEST_DVID_SERVER)
+        uuid = server.create_new_repo("testrepo", "This repo is for unit tests to use and abuse.");
+        return str(uuid)
+
+def delete_all_data_instances(uuid):
+    connection = DVIDConnection(TEST_DVID_SERVER)
+    repo_info_uri = "/repo/{uuid}/info".format( uuid=uuid )
+    status, body, error_message = connection.make_request( repo_info_uri, ConnectionMethod.GET)
+    assert status == httplib.OK, "Request for {} returned status {}".format(repo_info_uri, status)
+    assert error_message == ""
+    repo_info = json.loads(body)
+    for instance_name in repo_info["DataInstances"].keys():
+        status, body, error_message = connection.make_request( "/api/repo/{uuid}/{dataname}?imsure=true"
+                                                               .format( uuid=uuid, dataname=str(instance_name) ),
+                                                               ConnectionMethod.DELETE )            

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -1,0 +1,30 @@
+import unittest
+import json
+from libdvid import DVIDConnection, ConnectionMethod
+
+TEST_SERVER = "127.0.0.1:8000"
+
+class Test_DVIDConnection(unittest.TestCase):
+
+    def test_get(self):
+        connection = DVIDConnection(TEST_SERVER)
+        status, body, error_message = connection.make_request( "/server/info", ConnectionMethod.GET);
+        self.assertEqual(status, 200)
+        self.assertEqual(error_message, "")
+        
+        # This shouldn't raise an exception
+        json_data = json.loads(body)
+
+    def test_garbage_request(self):
+        connection = DVIDConnection(TEST_SERVER)
+        status, body, error_message = connection.make_request( "/does/not/exist", ConnectionMethod.GET);
+        
+        # No connection errors, just missing data.
+        self.assertEqual(error_message, "")
+
+        self.assertEqual(status, 404)
+        self.assertNotEqual(body, "")
+        
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -1,13 +1,12 @@
 import unittest
 import json
 from libdvid import DVIDConnection, ConnectionMethod
-
-TEST_SERVER = "127.0.0.1:8000"
+from _test_utils import TEST_DVID_SERVER
 
 class Test_DVIDConnection(unittest.TestCase):
 
     def test_get(self):
-        connection = DVIDConnection(TEST_SERVER)
+        connection = DVIDConnection(TEST_DVID_SERVER)
         status, body, error_message = connection.make_request( "/server/info", ConnectionMethod.GET);
         self.assertEqual(status, 200)
         self.assertEqual(error_message, "")
@@ -16,7 +15,7 @@ class Test_DVIDConnection(unittest.TestCase):
         json_data = json.loads(body)
 
     def test_garbage_request(self):
-        connection = DVIDConnection(TEST_SERVER)
+        connection = DVIDConnection(TEST_DVID_SERVER)
         status, body, error_message = connection.make_request( "/does/not/exist", ConnectionMethod.GET);
         
         # No connection errors, just missing data.

--- a/python/tests/test_node_service.py
+++ b/python/tests/test_node_service.py
@@ -1,0 +1,29 @@
+import unittest
+from libdvid import DVIDNodeService 
+
+TEST_SERVER = "127.0.0.1:8000"
+
+class Test_DVIDNodeService(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # FIXME: Create the repo and uuid 
+        cls.uuid = "87f0a170155f4b54933cc879346f04e6"
+
+    @classmethod
+    def tearDownClass(cls):
+        # TODO: clean up from setUpClass. 
+        pass
+
+    def test_keyvalue(self):
+        node_service = DVIDNodeService(TEST_SERVER, self.uuid)
+        node_service.create_keyvalue("stuart_keyvalue")
+        node_service.put("stuart_keyvalue", "kkkk", "vvvv")
+        readback_value = node_service.get("stuart_keyvalue", "kkkk")
+        self.assertEqual(readback_value, "vvvv")
+
+        with self.assertRaises(RuntimeError):
+            node_service.put("stuart_keyvalue", "kkkk", 123) # 123 is not a buffer.
+                
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_node_service.py
+++ b/python/tests/test_node_service.py
@@ -1,7 +1,8 @@
 import unittest
 import numpy
+import json
 
-from libdvid import DVIDNodeService 
+from libdvid import DVIDNodeService, ConnectionMethod
 
 TEST_SERVER = "127.0.0.1:8000"
 
@@ -16,6 +17,13 @@ class Test_DVIDNodeService(unittest.TestCase):
     def tearDownClass(cls):
         # TODO: clean up from setUpClass. 
         pass
+
+    def test_custom_request(self):
+        node_service = DVIDNodeService(TEST_SERVER, self.uuid)
+        response_body = node_service.custom_request( "log", "", ConnectionMethod.GET)
+        
+        # This shouldn't raise an exception
+        json_data = json.loads(response_body)
 
     def test_keyvalue(self):
         node_service = DVIDNodeService(TEST_SERVER, self.uuid)

--- a/python/tests/test_node_service.py
+++ b/python/tests/test_node_service.py
@@ -3,30 +3,27 @@ import numpy
 import json
 
 from libdvid import DVIDNodeService, ConnectionMethod
-
-TEST_SERVER = "127.0.0.1:8000"
+from _test_utils import TEST_DVID_SERVER, get_testrepo_root_uuid, delete_all_data_instances
 
 class Test_DVIDNodeService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # FIXME: Create the repo and uuid 
-        cls.uuid = "87f0a170155f4b54933cc879346f04e6"
-
+        cls.uuid = get_testrepo_root_uuid()
+    
     @classmethod
     def tearDownClass(cls):
-        # TODO: clean up from setUpClass. 
-        pass
+        delete_all_data_instances(cls.uuid)
 
     def test_custom_request(self):
-        node_service = DVIDNodeService(TEST_SERVER, self.uuid)
-        response_body = node_service.custom_request( "log", "", ConnectionMethod.GET)
+        node_service = DVIDNodeService(TEST_DVID_SERVER, self.uuid)
+        response_body = node_service.custom_request( "log", "", ConnectionMethod.GET )
         
         # This shouldn't raise an exception
         json_data = json.loads(response_body)
 
     def test_keyvalue(self):
-        node_service = DVIDNodeService(TEST_SERVER, self.uuid)
+        node_service = DVIDNodeService(TEST_DVID_SERVER, self.uuid)
         node_service.create_keyvalue("stuart_keyvalue")
         node_service.put("stuart_keyvalue", "kkkk", "vvvv")
         readback_value = node_service.get("stuart_keyvalue", "kkkk")
@@ -36,7 +33,7 @@ class Test_DVIDNodeService(unittest.TestCase):
             node_service.put("stuart_keyvalue", "kkkk", 123) # 123 is not a buffer.
 
     def test_grayscale8(self):
-        node_service = DVIDNodeService(TEST_SERVER, self.uuid)
+        node_service = DVIDNodeService(TEST_DVID_SERVER, self.uuid)
         node_service.create_grayscale8("stuart_grayscale")
         data = numpy.random.randint(0, 255, (128,128,128)).astype(numpy.uint8)
         node_service.put_gray3D( "stuart_grayscale", data, (0,0,0) )
@@ -44,7 +41,7 @@ class Test_DVIDNodeService(unittest.TestCase):
         self.assertTrue( (retrieved_data == data[20:50, 20:50, 20:50]).all() )
 
     def test_labels64(self):
-        node_service = DVIDNodeService(TEST_SERVER, self.uuid)
+        node_service = DVIDNodeService(TEST_DVID_SERVER, self.uuid)
         node_service.create_labelblk("stuart_labelblk")
         data = numpy.random.randint(0, 2**63-1, (128,128,128)).astype(numpy.uint64)
         node_service.put_labels3D( "stuart_labelblk", data, (0,0,0) )

--- a/python/tests/test_node_service.py
+++ b/python/tests/test_node_service.py
@@ -35,5 +35,13 @@ class Test_DVIDNodeService(unittest.TestCase):
         retrieved_data = node_service.get_gray3D( "stuart_grayscale", (30,30,30), (20,20,20) )
         self.assertTrue( (retrieved_data == data[20:50, 20:50, 20:50]).all() )
 
+    def test_labels64(self):
+        node_service = DVIDNodeService(TEST_SERVER, self.uuid)
+        node_service.create_labelblk("stuart_labelblk")
+        data = numpy.random.randint(0, 2**63-1, (128,128,128)).astype(numpy.uint64)
+        node_service.put_labels3D( "stuart_labelblk", data, (0,0,0) )
+        retrieved_data = node_service.get_labels3D( "stuart_labelblk", (30,30,30), (20,20,20) )
+        self.assertTrue( (retrieved_data == data[20:50, 20:50, 20:50]).all() )
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_node_service.py
+++ b/python/tests/test_node_service.py
@@ -1,4 +1,6 @@
 import unittest
+import numpy
+
 from libdvid import DVIDNodeService 
 
 TEST_SERVER = "127.0.0.1:8000"
@@ -21,9 +23,17 @@ class Test_DVIDNodeService(unittest.TestCase):
         node_service.put("stuart_keyvalue", "kkkk", "vvvv")
         readback_value = node_service.get("stuart_keyvalue", "kkkk")
         self.assertEqual(readback_value, "vvvv")
-
+ 
         with self.assertRaises(RuntimeError):
             node_service.put("stuart_keyvalue", "kkkk", 123) # 123 is not a buffer.
-                
+
+    def test_grayscale8(self):
+        node_service = DVIDNodeService(TEST_SERVER, self.uuid)
+        node_service.create_grayscale8("stuart_grayscale")
+        data = numpy.random.randint(0, 255, (128,128,128)).astype(numpy.uint8)
+        node_service.put_gray3D( "stuart_grayscale", data, (0,0,0) )
+        retrieved_data = node_service.get_gray3D( "stuart_grayscale", (30,30,30), (20,20,20) )
+        self.assertTrue( (retrieved_data == data[20:50, 20:50, 20:50]).all() )
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_node_service.py
+++ b/python/tests/test_node_service.py
@@ -24,28 +24,28 @@ class Test_DVIDNodeService(unittest.TestCase):
 
     def test_keyvalue(self):
         node_service = DVIDNodeService(TEST_DVID_SERVER, self.uuid)
-        node_service.create_keyvalue("stuart_keyvalue")
-        node_service.put("stuart_keyvalue", "kkkk", "vvvv")
-        readback_value = node_service.get("stuart_keyvalue", "kkkk")
+        node_service.create_keyvalue("test_keyvalue")
+        node_service.put("test_keyvalue", "kkkk", "vvvv")
+        readback_value = node_service.get("test_keyvalue", "kkkk")
         self.assertEqual(readback_value, "vvvv")
  
         with self.assertRaises(RuntimeError):
-            node_service.put("stuart_keyvalue", "kkkk", 123) # 123 is not a buffer.
+            node_service.put("test_keyvalue", "kkkk", 123) # 123 is not a buffer.
 
-    def test_grayscale8(self):
+    def test_grayscale_3d(self):
         node_service = DVIDNodeService(TEST_DVID_SERVER, self.uuid)
-        node_service.create_grayscale8("stuart_grayscale")
+        node_service.create_grayscale8("test_grayscale_3d")
         data = numpy.random.randint(0, 255, (128,128,128)).astype(numpy.uint8)
-        node_service.put_gray3D( "stuart_grayscale", data, (0,0,0) )
-        retrieved_data = node_service.get_gray3D( "stuart_grayscale", (30,30,30), (20,20,20) )
+        node_service.put_gray3D( "test_grayscale_3d", data, (0,0,0) )
+        retrieved_data = node_service.get_gray3D( "test_grayscale_3d", (30,30,30), (20,20,20) )
         self.assertTrue( (retrieved_data == data[20:50, 20:50, 20:50]).all() )
 
-    def test_labels64(self):
+    def test_labels_3d(self):
         node_service = DVIDNodeService(TEST_DVID_SERVER, self.uuid)
-        node_service.create_labelblk("stuart_labelblk")
+        node_service.create_labelblk("test_labels_3d")
         data = numpy.random.randint(0, 2**63-1, (128,128,128)).astype(numpy.uint64)
-        node_service.put_labels3D( "stuart_labelblk", data, (0,0,0) )
-        retrieved_data = node_service.get_labels3D( "stuart_labelblk", (30,30,30), (20,20,20) )
+        node_service.put_labels3D( "test_labels_3d", data, (0,0,0) )
+        retrieved_data = node_service.get_labels3D( "test_labels_3d", (30,30,30), (20,20,20) )
         self.assertTrue( (retrieved_data == data[20:50, 20:50, 20:50]).all() )
 
 if __name__ == "__main__":

--- a/python/tests/test_node_service.py
+++ b/python/tests/test_node_service.py
@@ -2,7 +2,7 @@ import unittest
 import numpy
 import json
 
-from libdvid import DVIDNodeService, ConnectionMethod
+from libdvid import DVIDNodeService, ConnectionMethod, Slice2D
 from _test_utils import TEST_DVID_SERVER, get_testrepo_root_uuid, delete_all_data_instances
 
 class Test_DVIDNodeService(unittest.TestCase):
@@ -47,6 +47,13 @@ class Test_DVIDNodeService(unittest.TestCase):
         node_service.put_labels3D( "test_labels_3d", data, (0,0,0) )
         retrieved_data = node_service.get_labels3D( "test_labels_3d", (30,30,30), (20,20,20) )
         self.assertTrue( (retrieved_data == data[20:50, 20:50, 20:50]).all() )
+
+    @unittest.skip("FIXME: No way to create tile data via the DVID http API.")
+    def test_grayscale_2d_tile(self):
+        # Create tile data here...
+
+        # Now retrieve a tile.
+        retrieved_tile = node_service.get_tile_slice( "test_grayscale_2d_tile", Slice2D.XY, 0, (0,0,0) )
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/DVIDConnection.cpp
+++ b/src/DVIDConnection.cpp
@@ -31,6 +31,8 @@ WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
 
 namespace libdvid {
 
+const int DVIDConnection::DEFAULT_TIMEOUT;
+
 //! Defines DVID prefix -- this might have a version ID eventually 
 string DVIDConnection::DVID_PREFIX = "/api";
 

--- a/src/DVIDNodeService.cpp
+++ b/src/DVIDNodeService.cpp
@@ -186,7 +186,7 @@ Labels3D DVIDNodeService::get_labels3D(string datatype_instance, Dims_t sizes,
             throttle, compress, roi);
 }
 
-void DVIDNodeService::put_labels3D(string datatype_instance, Labels3D& volume,
+void DVIDNodeService::put_labels3D(string datatype_instance, Labels3D const & volume,
             vector<unsigned int> offset, bool throttle, bool compress, string roi)
 {
     Dims_t sizes = volume.get_dims();
@@ -194,7 +194,7 @@ void DVIDNodeService::put_labels3D(string datatype_instance, Labels3D& volume,
             offset, throttle, compress, roi);
 }
 
-void DVIDNodeService::put_gray3D(string datatype_instance, Grayscale3D& volume,
+void DVIDNodeService::put_gray3D(string datatype_instance, Grayscale3D const & volume,
             vector<unsigned int> offset, bool throttle, bool compress)
 {
     Dims_t sizes = volume.get_dims();


### PR DESCRIPTION
This PR adds Python support for a subset of `libdvid` functionality, including:

- `DVIDConnection`
- `DVIDServerService`
- `DVIDNodeService`
 - Supported: keyvalue, grayscale3D, label3D, tile slices, typeinfo, custom_request
 - Not yet supported: blocks methods, graph methods

See `python/src/test_node_service.py` for example usage.