### PR TITLE
add HEAD request and body_exists

### DIFF
--- a/libdvid/DVIDConnection.h
+++ b/libdvid/DVIDConnection.h
@@ -14,7 +14,7 @@
 namespace libdvid {
 
 //! Define connection methods
-enum ConnectionMethod { GET, POST, PUT, DELETE};
+enum ConnectionMethod { HEAD, GET, POST, PUT, DELETE};
 
 //! Define connection types
 enum ConnectionType {DEFAULT, JSON, BINARY};
@@ -52,13 +52,22 @@ class DVIDConnection {
     */
     ~DVIDConnection();
 
-    /*!
+     /*!
+     * Simple HEAD requests to DVID.  An exception is generated
+     * if curl cannot properly connect to the URL.
+     *
+     * \param url endpoint where request is performed
+     * \return html status code
+    */ 
+    int make_head_request(std::string endpoint);
+
+   /*!
      * Main helper function retrieving data from DVID.  The function
      * performs the action specified in method.  An exception is generated
      * if curl cannot properly connect to the URL.
      *
      * \param url endpoint where request is performed
-     * \param method http verb (GET, POST, PUT, DELETE)
+     * \param method http verb (HEAD, GET, POST, PUT, DELETE)
      * \param payload binary data containing data to be posted
      * \param results binary data containing the result
      * \param error_msg error message if there is an error

--- a/python/src/libdvid_python.cpp
+++ b/python/src/libdvid_python.cpp
@@ -17,6 +17,19 @@
 
 namespace libdvid { namespace python {
 
+    //! Python wrapper function for DVIDConnection::make_head_request().
+    //! (Since "return-by-reference" is not an option in Python, boost::python can't provide an automatic wrapper.)
+    //! Returns a tuple: (status, error_msg)
+    boost::python::tuple make_head_request( DVIDConnection & connection,
+                                            std::string endpoint )
+    {
+        using namespace boost::python;
+
+        std::string err_msg; // TODO -- actually set errors if head request returns them.
+        int status_code = connection.make_head_request(endpoint);
+        return make_tuple(status_code, err_msg);
+    }
+
     //! Python wrapper function for DVIDConnection::make_request().
     //! (Since "return-by-reference" is not an option in Python, boost::python can't provide an automatic wrapper.)
     //! Returns a tuple: (status, result_body, error_msg)
@@ -160,6 +173,8 @@ namespace libdvid { namespace python {
 
         // DVIDConnection python class definition
         class_<DVIDConnection>("DVIDConnection", init<std::string>())
+            .def("make_head_request", &make_head_request,
+                                 ( arg("connection"), arg("endpoint") ))
             .def("make_request", &make_request,
                                  ( arg("connection"), arg("endpoint"), arg("method"), arg("payload")=object(), arg("timeout")=DVIDConnection::DEFAULT_TIMEOUT ))
             .def("get_addr", &DVIDConnection::get_addr)
@@ -167,6 +182,7 @@ namespace libdvid { namespace python {
         ;
 
         enum_<ConnectionMethod>("ConnectionMethod")
+            .value("HEAD", HEAD)
             .value("GET", GET)
             .value("POST", POST)
             .value("PUT", PUT)
@@ -207,12 +223,13 @@ namespace libdvid { namespace python {
                 ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false))
 
             // labels
-           .def("create_labelblk", create_labelblk, (arg("service"), arg("instance"), arg("instance2")=object() ))
-           .def("get_labels3D", get_labels3D,
+            .def("create_labelblk", create_labelblk, (arg("service"), arg("instance"), arg("instance2")=object() ))
+            .def("get_labels3D", get_labels3D,
                 ( arg("service"), arg("instance"), arg("dims"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
-           .def("get_label_by_location",  &DVIDNodeService::get_label_by_location)
-           .def("put_labels3D", put_labels3D,
+            .def("get_label_by_location",  &DVIDNodeService::get_label_by_location)
+            .def("put_labels3D", put_labels3D,
                 ( arg("service"), arg("instance"), arg("ndarray"), arg("offset"), arg("throttle")=true, arg("compress")=false, arg("roi")=object() ))
+            .def("body_exists", &DVIDNodeService::body_exists)
 
             // 2D slices
             .def("get_tile_slice", &DVIDNodeService::get_tile_slice)

--- a/src/DVIDConnection.cpp
+++ b/src/DVIDConnection.cpp
@@ -52,6 +52,32 @@ DVIDConnection::~DVIDConnection()
     curl_easy_cleanup(curl_connection);
 }
 
+int DVIDConnection::make_head_request(string endpoint) {
+    CURLcode result;
+
+    // load url
+    string url = get_uri_root() + endpoint;
+    curl_easy_setopt(curl_connection, CURLOPT_URL, url.c_str());
+
+    curl_easy_setopt(curl_connection, CURLOPT_CUSTOMREQUEST, "HEAD");
+    struct curl_slist *headers=0;
+    curl_easy_setopt(curl_connection, CURLOPT_NOBODY, 1);
+    curl_easy_setopt(curl_connection, CURLOPT_HTTPHEADER, headers);
+    result = curl_easy_perform(curl_connection);
+    
+    // get the error code
+    long http_code = 0;
+    curl_easy_getinfo (curl_connection, CURLINFO_RESPONSE_CODE, &http_code);
+    
+    curl_easy_setopt(curl_connection, CURLOPT_NOBODY, 0);
+
+    // throw exception if connection doesn't work
+    if (result != CURLE_OK) {
+        throw DVIDException("DVIDConnection error: " + string(url), http_code);
+    }
+    return int(http_code);
+}
+
 int DVIDConnection::make_request(string endpoint, ConnectionMethod method,
         BinaryDataPtr payload, BinaryDataPtr results, string& error_msg,
         ConnectionType type, int timeout)

--- a/src/DVIDNodeService.cpp
+++ b/src/DVIDNodeService.cpp
@@ -923,8 +923,19 @@ void DVIDNodeService::roi_ptquery(std::string roi_name,
     
 bool DVIDNodeService::body_exists(string labelvol_name, uint64 bodyid) 
 {
-    vector<BlockXYZ> blockcoords;
-    return get_coarse_body(labelvol_name, bodyid, blockcoords);
+    stringstream sstr;
+    sstr << "/" << labelvol_name << "/sparsevol/";
+    sstr << bodyid;
+    string node_endpoint = "/node/" + uuid + sstr.str();
+    int status_code = connection.make_head_request(node_endpoint);
+    if (status_code == 200) {
+        return true;
+    } else if (status_code == 204) {
+        return false;
+    } else {
+        throw ErrMsg("Returned bad status code from HEAD request on sparsevol");
+    }
+    return false;
 }
     
 PointXYZ DVIDNodeService::get_body_location(string labelvol_name,

--- a/tests/test_body.cpp
+++ b/tests/test_body.cpp
@@ -101,7 +101,7 @@ int main(int argc, char** argv)
         // check that the correct coarse volume is returned
         vector<BlockXYZ> blockcoords;
         dvid_node.get_coarse_body(labelvol_datatype_name, uint64(5), blockcoords);
-
+        
         if (blockcoords.size() != 4) {
             throw ErrMsg("4 blocks should exist for body 5");
         }


### PR DESCRIPTION
On testing, using a DVID server that remains up between "make test" runs will return an error on test 12 (python_test_node_service) on the 2nd and later test runs.