### PR TITLE
Use pkg-config to find include directories when on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,16 +109,28 @@ else ()
     endif()
 
 
-    FIND_LIBRARY(json_LIB jsoncpp)
     FIND_PACKAGE(PNG REQUIRED)
     FIND_PACKAGE(JPEG REQUIRED)
     FIND_PACKAGE(CURL REQUIRED)
     FIND_LIBRARY(LZ4_LIBRARY lz4)
+
     if (NOT LZ4_LIBRARY)
         message(FATAL_ERROR "*** Could not find lz4 library ***")
-    endif()    
+    endif()
 
-    set (support_LIBS ${json_LIB} ${boost_LIBS} ${PNG_LIBRARIES} ${CURL_LIBRARIES} ${JPEG_LIBRARIES} ${LZ4_LIBRARY})
+    if (UNIX AND NOT APPLE)
+        include (FindPkgConfig)
+        PKG_SEARCH_MODULE(JSON REQUIRED jsoncpp)
+        include_directories(BEFORE ${JSON_INCLUDE_DIRS})
+    else()
+        FIND_LIBRARY(JSON_LIBRARIES jsoncpp)
+
+        if (NOT JSON_LIBRARIES)
+            message(FATAL_ERROR "*** Could not find jsoncpp library ***")
+        endif()
+    endif()
+
+    set (support_LIBS ${JSON_LIBRARIES} ${boost_LIBS} ${PNG_LIBRARIES} ${CURL_LIBRARIES} ${JPEG_LIBRARIES} ${LZ4_LIBRARY})
 endif (NOT ${BUILDEM_DIR} STREQUAL "None")
 
 include_directories (BEFORE ${CMAKE_SOURCE_DIR}/libdvid ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
Libdvidcpp does not compile against the system libraries on Debian and Ubuntu. Both of these distributions place the header files under /usr/include/jsonccp/json/ instead of /usr/include/json/. The compilation of libdvidcpp then fails due to missing header files.

Luckily, libjsoncpp ships with a .pc file for pkg-config. With the changes in this commit, cmake calls to pkg-config in order to query the proper include directory. Because OS X and Windows do not ship with pkg-config installed by default, this change only applies to Linux for now.