### PR TITLE
conda install command missing conda-forge channel

### DIFF
--- a/python/docs/source/index.rst
+++ b/python/docs/source/index.rst
@@ -13,7 +13,7 @@ Installation
 
 .. code-block:: bash
 
-   conda install -c flyem libdvid-cpp
+   conda install -c flyem -c conda-forge libdvid-cpp
 
 Tutorials
 =========


### PR DESCRIPTION
just a tiny one in the docs